### PR TITLE
Allow to configure whether to show a confirmation toast on exit

### DIFF
--- a/lib/constants/themes.dart
+++ b/lib/constants/themes.dart
@@ -66,6 +66,7 @@ abstract class Theme {
       primaryColor: defaultPrimaryColor,
       disabledColor: Colors.grey.shade400,
       unselectedWidgetColor: Colors.grey.shade400,
+      toggleableActiveColor: defaultPrimaryColor,
 
       //****************** Color scheme (preferable to colors) *********************
       colorScheme: const ColorScheme(
@@ -191,6 +192,7 @@ abstract class Theme {
       primaryColor: defaultPrimaryColor,
       disabledColor: Colors.grey.shade800,
       unselectedWidgetColor: Colors.grey.shade800,
+      toggleableActiveColor: defaultPrimaryColor,
 
       //****************** Color scheme (preferable to colors) *********************
       colorScheme: const ColorScheme(

--- a/lib/localization/arb/intl_en.arb
+++ b/lib/localization/arb/intl_en.arb
@@ -607,5 +607,6 @@
   "@openAppSettingsError": {
     "type": "text",
     "placeholders": {}
-  }
+  },
+  "confirmBeforeExitingSetting": "Show confirmation before exiting"
 }

--- a/lib/localization/arb/intl_en.arb
+++ b/lib/localization/arb/intl_en.arb
@@ -608,8 +608,8 @@
     "type": "text",
     "placeholders": {}
   },
-  "confirmBeforeExitingSetting": "Confirm exiting with back button",
-  "@confirmBeforeExitingSetting": {
+  "confirmExitingWithBackButtonSetting": "Confirm exiting with back button",
+  "@confirmExitingWithBackButtonSetting": {
     "type": "text",
     "placeholders": {}
   }

--- a/lib/localization/arb/intl_en.arb
+++ b/lib/localization/arb/intl_en.arb
@@ -608,5 +608,9 @@
     "type": "text",
     "placeholders": {}
   },
-  "confirmBeforeExitingSetting": "Show confirmation before exiting"
+  "confirmBeforeExitingSetting": "Confirm exiting with back button",
+  "@confirmBeforeExitingSetting": {
+    "type": "text",
+    "placeholders": {}
+  }
 }

--- a/lib/localization/arb/intl_ru.arb
+++ b/lib/localization/arb/intl_ru.arb
@@ -587,8 +587,8 @@
      "type": "text",
      "placeholders": {}
   },
-  "confirmBeforeExitingSetting": "Подтверждать выход кнопкой назад",
-  "@confirmBeforeExitingSetting": {
+  "confirmExitingWithBackButtonSetting": "Подтверждать выход кнопкой назад",
+  "@confirmExitingWithBackButtonSetting": {
     "type": "text",
     "placeholders": {}
   }

--- a/lib/localization/arb/intl_ru.arb
+++ b/lib/localization/arb/intl_ru.arb
@@ -586,5 +586,10 @@
   "@openAppSettingsError": {
      "type": "text",
      "placeholders": {}
+  },
+  "confirmBeforeExitingSetting": "Подтверждать выход кнопкой назад",
+  "@confirmBeforeExitingSetting": {
+    "type": "text",
+    "placeholders": {}
   }
 }

--- a/lib/logic/prefs.dart
+++ b/lib/logic/prefs.dart
@@ -86,8 +86,9 @@ abstract class Prefs {
   /// * song info button available in the top right menu of [PlayerRoute].
   static final devMode = PrefNotifier(const BoolPref('dev_mode', false));
   
-  /// Whether a confirmation toast should be displayed when exiting the app. 
-  static final confirmOnExit = PrefNotifier(const BoolPref('confirm_app_exit', true));
+  /// Whether a confirmation toast should be displayed when exiting
+  /// the app with back button.
+  static final confirmExitingWithBackButton = PrefNotifier(const BoolPref('confirm_exiting_with_back_button', true));
 }
 
 class SearchHistory {

--- a/lib/logic/prefs.dart
+++ b/lib/logic/prefs.dart
@@ -85,6 +85,9 @@ abstract class Prefs {
   /// * error snackbars are shown
   /// * song info button available in the top right menu of [PlayerRoute].
   static final devMode = PrefNotifier(const BoolPref('dev_mode', false));
+  
+  /// Whether a confirmation toast should be displayed when exiting the app. 
+  static final confirmOnExit = PrefNotifier(const BoolPref('confirm_app_exit', true));
 }
 
 class SearchHistory {

--- a/lib/logic/theme.dart
+++ b/lib/logic/theme.dart
@@ -134,6 +134,7 @@ abstract class ThemeControl {
     Constants.Theme.app = Constants.Theme.app.copyWith(
       light: Constants.Theme.app.light.copyWith(
         primaryColor: color,
+        toggleableActiveColor: color,
         colorScheme: Constants.Theme.app.light.colorScheme.copyWith(
           primary: color,
           onSecondary: color,
@@ -157,6 +158,7 @@ abstract class ThemeControl {
         // In dark mode I also have splashColor set to be primary
         splashColor: color,
         primaryColor: color,
+        toggleableActiveColor: color,
         colorScheme: Constants.Theme.app.dark.colorScheme.copyWith(
           primary: color,
         ),

--- a/lib/routes/home_route/tabs_route.dart
+++ b/lib/routes/home_route/tabs_route.dart
@@ -152,7 +152,7 @@ class TabsRouteState extends State<TabsRoute> with TickerProviderStateMixin, Sel
       return true;
     }
 
-    if (!selectionRoute) {
+    if (!selectionRoute && Prefs.confirmOnExit.get()) {
       final now = DateTime.now();
       // Show toast when user presses back button on main route, that
       // asks from user to press again to confirm that he wants to quit the app

--- a/lib/routes/home_route/tabs_route.dart
+++ b/lib/routes/home_route/tabs_route.dart
@@ -152,7 +152,7 @@ class TabsRouteState extends State<TabsRoute> with TickerProviderStateMixin, Sel
       return true;
     }
 
-    if (!selectionRoute && Prefs.confirmOnExit.get()) {
+    if (!selectionRoute && Prefs.confirmExitingWithBackButton.get()) {
       final now = DateTime.now();
       // Show toast when user presses back button on main route, that
       // asks from user to press again to confirm that he wants to quit the app

--- a/lib/routes/routes.dart
+++ b/lib/routes/routes.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart' hide LicensePage;
 import 'package:equatable/equatable.dart';
+import 'package:sweyer/routes/settings_route/general_settings.dart';
 import 'package:sweyer/routes/settings_route/theme_settings.dart';
 import 'package:sweyer/sweyer.dart';
 import 'package:sweyer/constants.dart' as Constants;
@@ -58,6 +59,7 @@ class AppRoutes<T> extends _Routes<T> {
 
   static const initial = AppRoutes<void>._('/');
   static const settings = AppRoutes<void>._('/settings');
+  static const generalSettings = AppRoutes<void>._('/settings/general');
   static const themeSettings = AppRoutes<void>._('/settings/theme');
   static const licenses = AppRoutes<void>._('/settings/licenses');
   static const dev = AppRoutes<void>._('/dev');
@@ -373,6 +375,12 @@ class AppRouter extends RouterDelegate<AppRoutes<Object?>>
               key: AppRoutes.settings.uniqueKey,
               child: const SettingsRoute(),
               transitionSettings: transitionSettings.dismissible,
+            ));
+          } else if (route.hasSameLocation(AppRoutes.generalSettings)) {
+            pages.add(StackFadePage(
+              key: AppRoutes.generalSettings.uniqueKey,
+              child: const GeneralSettingsRoute(),
+              transitionSettings: transitionSettings.theme,
             ));
           } else if (route.hasSameLocation(AppRoutes.themeSettings)) {
             pages.add(StackFadePage(

--- a/lib/routes/settings_route/general_settings.dart
+++ b/lib/routes/settings_route/general_settings.dart
@@ -11,14 +11,6 @@ class _GeneralSettingsRouteState extends State<GeneralSettingsRoute> {
   /// Needed as init value and also to check whether setting
   /// value has been increased or decreased.
   int minFileDuration = 30;
-  /// Whether to show a confirmation toast before exiting the app
-  late bool confirmOnExitEnabled;
-
-  @override
-  void initState() {
-    super.initState();
-    confirmOnExitEnabled = Prefs.confirmOnExit.get();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -30,10 +22,13 @@ class _GeneralSettingsRouteState extends State<GeneralSettingsRoute> {
       body: ListView(
         physics: const NeverScrollableScrollPhysics(),
         children: [
-          SwitchListTile(
-            title: Text(l10n.confirmBeforeExitingSetting),
-            value: confirmOnExitEnabled,
-            onChanged: _handleConfirmOnExitSwitch,
+          ValueListenableBuilder(
+            valueListenable: Prefs.confirmOnExit,
+            builder: (context, value, child) => SwitchListTile(
+              title: Text(l10n.confirmBeforeExitingSetting),
+              value: Prefs.confirmOnExit.get(),
+              onChanged: Prefs.confirmOnExit.set,
+            ),
           ),
           // _MinFileDurationSlider(
           //   initValue: minFileDuration,
@@ -41,15 +36,6 @@ class _GeneralSettingsRouteState extends State<GeneralSettingsRoute> {
         ],
       ),
     );
-  }
-  
-  /// Handle a change of the exit confirmation setting
-  /// and update the preference and the screen. 
-  void _handleConfirmOnExitSwitch(bool newValue) {
-    Prefs.confirmOnExit.set(newValue);
-    setState(() {
-      confirmOnExitEnabled = newValue;
-    });
   }
 }
 

--- a/lib/routes/settings_route/general_settings.dart
+++ b/lib/routes/settings_route/general_settings.dart
@@ -22,11 +22,11 @@ class _GeneralSettingsRouteState extends State<GeneralSettingsRoute> {
       body: ListView(
         physics: const NeverScrollableScrollPhysics(),
         children: [
-          ValueListenableBuilder(
+          ValueListenableBuilder<bool>(
             valueListenable: Prefs.confirmOnExit,
             builder: (context, value, child) => SwitchListTile(
               title: Text(l10n.confirmBeforeExitingSetting),
-              value: Prefs.confirmOnExit.get(),
+              value: value,
               onChanged: Prefs.confirmOnExit.set,
             ),
           ),

--- a/lib/routes/settings_route/general_settings.dart
+++ b/lib/routes/settings_route/general_settings.dart
@@ -23,11 +23,11 @@ class _GeneralSettingsRouteState extends State<GeneralSettingsRoute> {
         physics: const NeverScrollableScrollPhysics(),
         children: [
           ValueListenableBuilder<bool>(
-            valueListenable: Prefs.confirmOnExit,
+            valueListenable: Prefs.confirmExitingWithBackButton,
             builder: (context, value, child) => SwitchListTile(
-              title: Text(l10n.confirmBeforeExitingSetting),
+              title: Text(l10n.confirmExitingWithBackButtonSetting),
               value: value,
-              onChanged: Prefs.confirmOnExit.set,
+              onChanged: Prefs.confirmExitingWithBackButton.set,
             ),
           ),
           // _MinFileDurationSlider(

--- a/lib/routes/settings_route/general_settings.dart
+++ b/lib/routes/settings_route/general_settings.dart
@@ -11,6 +11,14 @@ class _GeneralSettingsRouteState extends State<GeneralSettingsRoute> {
   /// Needed as init value and also to check whether setting
   /// value has been increased or decreased.
   int minFileDuration = 30;
+  /// Whether to show a confirmation toast before exiting the app
+  late bool confirmOnExitEnabled;
+
+  @override
+  void initState() {
+    super.initState();
+    confirmOnExitEnabled = Prefs.confirmOnExit.get();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -21,13 +29,27 @@ class _GeneralSettingsRouteState extends State<GeneralSettingsRoute> {
       ),
       body: ListView(
         physics: const NeverScrollableScrollPhysics(),
-        children: const [
+        children: [
+          SwitchListTile(
+            title: Text(l10n.confirmBeforeExitingSetting),
+            value: confirmOnExitEnabled,
+            onChanged: _handleConfirmOnExitSwitch,
+          ),
           // _MinFileDurationSlider(
           //   initValue: minFileDuration,
           // ),
         ],
       ),
     );
+  }
+  
+  /// Handle a change of the exit confirmation setting
+  /// and update the preference and the screen. 
+  void _handleConfirmOnExitSwitch(bool newValue) {
+    Prefs.confirmOnExit.set(newValue);
+    setState(() {
+      confirmOnExitEnabled = newValue;
+    });
   }
 }
 

--- a/lib/routes/settings_route/settings_route.dart
+++ b/lib/routes/settings_route/settings_route.dart
@@ -42,7 +42,7 @@ class _SettingsRouteState extends State<SettingsRoute> {
               children: <Widget>[
                 MenuItem(
                   l10n.general,
-                  icon: Icons.build,
+                  icon: Icons.build_rounded,
                   iconSize: 25.0,
                   fontSize: 16.0,
                   onTap: _handleClickGeneralSettings,

--- a/lib/routes/settings_route/settings_route.dart
+++ b/lib/routes/settings_route/settings_route.dart
@@ -7,8 +7,6 @@ import 'package:sweyer/constants.dart' as Constants;
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-// import 'general_settings.dart';
-// import 'licenses_route.dart';
 
 class SettingsRoute extends StatefulWidget {
   const SettingsRoute({Key? key}) : super(key: key);
@@ -17,9 +15,9 @@ class SettingsRoute extends StatefulWidget {
 }
 
 class _SettingsRouteState extends State<SettingsRoute> {
-  // void _handleClickGeneralSettings() {
-  //   _pushRoute(const GeneralSettingsRoute());
-  // }
+  void _handleClickGeneralSettings() {
+    AppRouter.instance.goto(AppRoutes.generalSettings);
+  }
 
   void _handleClickThemeSettings() {
     AppRouter.instance.goto(AppRoutes.themeSettings);
@@ -42,13 +40,13 @@ class _SettingsRouteState extends State<SettingsRoute> {
               physics: const NeverScrollableScrollPhysics(),
               padding: const EdgeInsets.only(top: 10.0),
               children: <Widget>[
-                // MenuItem(
-                //   l10n.general,
-                //   icon: Icons.menu_book_rounded,
-                //   iconSize: 25.0,
-                //   fontSize: 16.0,
-                //   onTap: _handleClickGeneralSettings,
-                // ),
+                MenuItem(
+                  l10n.general,
+                  icon: Icons.build,
+                  iconSize: 25.0,
+                  fontSize: 16.0,
+                  onTap: _handleClickGeneralSettings,
+                ),
                 MenuItem(
                   l10n.theme,
                   icon: Icons.palette_rounded,


### PR DESCRIPTION
This add back the general settings page and adds a new toggle setting to configure whether the shows the confirmation toast on exit.
I personally prefer that the app would just exit, as it is designed to run in the background anyways. Therefore I would like to have an option to toggle this behavior.

### The new setting and its effect
![Confirm exit setting demonstration](https://user-images.githubusercontent.com/6966049/166930611-aa8e1502-e1d0-42ea-964f-7b4bcd12eade.gif)
