### PR TITLE
Add missing padding on the right of the ContentChip list

### DIFF
--- a/lib/routes/home_route/search_route.dart
+++ b/lib/routes/home_route/search_route.dart
@@ -544,7 +544,7 @@ class _SearchRouteState extends State<SearchRoute> with SelectionHandlerMixin {
                     widget.delegate._chipsBarDragged = false;
                   },
                   child: SingleChildScrollView(
-                    padding: const EdgeInsets.only(left: 12.0),
+                    padding: const EdgeInsets.symmetric(horizontal: 12.0),
                     scrollDirection: Axis.horizontal,
                     child: Row(
                       children: children,


### PR DESCRIPTION
This is a missing padding on the right side of the ContentChip list that is used in the search route. The problem was visible on devices with smaller screen sizes.
I manually changed the translation to make it visible for the gifs, look at the right side:

| Before | After |
|--------|-------|
| ![Search result ContentChip list - Before](https://user-images.githubusercontent.com/6966049/167123082-b5e0f514-d2e8-4857-9a24-9a4104fe90fe.gif) | ![Search result ContentChip list - After](https://user-images.githubusercontent.com/6966049/167123096-95aa7923-0d30-4094-bc45-0dfb3b934629.gif) |
 