### PR TITLE
Integrate codecov

### DIFF
--- a/.github/workflows/sweyer.yml
+++ b/.github/workflows/sweyer.yml
@@ -13,8 +13,5 @@ jobs:
         with:
           testing_arguments: --coverage
 
-      - name: 📊 Check Code Coverage
-        uses: VeryGoodOpenSource/very_good_coverage@v1
-        with:
-          path: coverage/lcov.info
-          min_coverage: 0
+      - name: ☂ Upload Code Coverage
+        uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -84,8 +84,11 @@ untranslated-messages.txt
 
 .fvm/flutter_sdk
 
-# ignore golden failure outputs
+# Ignore golden failure outputs
 **/failures/*.png
+
+# Coverage results
+coverage
 
 .project
 .classpath

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,3 +53,9 @@ golden files:
 
 If you left the auto-commit option unchecked, those new files can be put into `test/golden/goldens`
 folder and manually pushed to your PR.
+
+## Coverage [![codecov](https://codecov.io/gh/nt4f04uNd/sweyer/branch/master/graph/badge.svg)](https://codecov.io/gh/nt4f04uNd/sweyer)
+
+Coverage measures which lines of code are covered during the tests. It shows which part of the
+code is untested. When adding a new feature, a test must be added to verify the new feature and to
+avoid reducing the test coverage.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
I think it would be nice be able to see code coverage online with [codecov](https://about.codecov.io). The only thing left to do for this to work is to create an account named `nt4f04uNd` with codecov and create a projecte named `sweyer`. Uploading coverage information should just work after that. There is no need to add a token to GitHub for public projects.

When the first coverage is uploaded we should check if we need the [dart-full-coverage action](https://github.com/marketplace/actions/dart-full-coverage). It sounds like by default files not loaded during the test don't count towards the coverage result? We'll have to see if that's true.