### PR TITLE
Don't fail the CI if coverage decreases

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,6 @@
 comment: false
+coverage:
+  status:
+    project:
+      default:
+        informational: true

--- a/lib/logic/player/music_player.dart
+++ b/lib/logic/player/music_player.dart
@@ -658,7 +658,12 @@ class MusicPlayer extends AudioPlayer {
 
   Future<void> init() async {
     await restoreLastSong();
-    handler?._init(this);  // In case the handler already exists, reinitialize it.
+
+    // Reinitialize the AudioHandler if it already exists. Otherwise it is
+    // initialized by the AudioService. The AudioService must only ever be
+    // initialized once per process, but the handler depends on the MusicPlayer,
+    // which can be disposed and recreated.
+    handler?._init(this);
     handler ??= await AudioService.init(builder: () {
         return AudioHandler(MusicPlayer.instance);
       },

--- a/lib/logic/player/music_player.dart
+++ b/lib/logic/player/music_player.dart
@@ -658,7 +658,7 @@ class MusicPlayer extends AudioPlayer {
 
   Future<void> init() async {
     await restoreLastSong();
-    await handler?._init(this);
+    await handler?._init(this);  // In case the handler already exists, reinitialize it.
     handler ??= await AudioService.init(builder: () {
         return AudioHandler(MusicPlayer.instance);
       },

--- a/lib/logic/player/music_player.dart
+++ b/lib/logic/player/music_player.dart
@@ -193,7 +193,7 @@ class AudioHandler extends BaseAudioHandler with SeekHandler, WidgetsBindingObse
   late StreamSubscription playbackSubscriber;
   late StreamSubscription queueSubscriber;
 
-  Future<void> _init(MusicPlayer player) async {
+  void _init(MusicPlayer player) {
     _disposed = false;
     this.player = player;
     WidgetsBinding.instance!.addObserver(this);
@@ -658,7 +658,7 @@ class MusicPlayer extends AudioPlayer {
 
   Future<void> init() async {
     await restoreLastSong();
-    await handler?._init(this);  // In case the handler already exists, reinitialize it.
+    handler?._init(this);  // In case the handler already exists, reinitialize it.
     handler ??= await AudioService.init(builder: () {
         return AudioHandler(MusicPlayer.instance);
       },

--- a/test/routes/player_route_test.dart
+++ b/test/routes/player_route_test.dart
@@ -163,14 +163,19 @@ void main() {
       );
 
       expect(MusicPlayer.instance.playing, false);
+      expect(MusicPlayer.handler!.running, false);
 
       await tester.tap(button);
       expect(MusicPlayer.instance.playing, true);
+      expect(MusicPlayer.handler!.running, true);
 
       await tester.tap(button);
       expect(MusicPlayer.instance.playing, false);
+      expect(MusicPlayer.handler!.running, true,
+          reason: 'Handler should only stop when stopped, not when paused');
 
       await tester.pumpAndSettle();
     });
+    expect(MusicPlayer.handler!.running, false);
   });
 }


### PR DESCRIPTION
This was enabled by default, now the two codecov status checks will always succeed.

This also fixes one source of unstable coverage, the `AudioHandler` wasn't properly re-initialized between tests. Let's see if that was the only source of coverage instability.