### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,13 +1,10 @@
 name: Bug report
-description: Report any issues that you have found with the Sweyer app. Please check open issues first, in case it has already been reported.
+description: Report any issues that you have found with the app.
 labels: [bug]
 body:
   - type: markdown
     attributes:
-      value: |
-        Thank you for taking the time and filling out this bug report!
-
-        Please [check open issues](https://github.com/nt4f04uNd/sweyer/issues) first, in case it has already been reported.
+      value: Thank you for taking the time and filling out this bug report!
   - type: textarea
     id: reproduction-steps
     attributes:
@@ -21,15 +18,17 @@ body:
     validations:
       required: true
   - type: textarea
-    id: result
+    id: expected
     attributes:
-      label: Outcome
-      placeholder: Tell us what went wrong
-      value: |
-        #### What did you expect?
-
-        #### What happened instead?
-        
+      label: What did you expect?
+      placeholder: Tell us what you thought should happen.
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: What happened instead?
+      placeholder: Tell us what went actually happened.
     validations:
       required: true
   - type: input
@@ -44,7 +43,7 @@ body:
     id: android-version
     attributes:
       label: Android version
-      description: The Andorid version of your device. You can leave this empty if you are sure that it's not important, if you are unsure please specify. 
+      description: The Andorid version of your device. 
       placeholder: e.g. Android 12 or Android Snow Cone
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,50 @@
+name: Bug report
+description: Report any issues that you have found with the Sweyer app. Please check open issues first, in case it has already been reported.
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time and filling out this bug report!
+
+        Please [check open issues](https://github.com/nt4f04uNd/sweyer/issues) first, in case it has already been reported.
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce
+      description: Please attach screenshots, videos or logs if you can.
+      placeholder: Describe what you did to trigger the bug.
+      value: |
+        1. Where are you starting? What can you see?
+        2. What do you click?
+        3. More steps…
+    validations:
+      required: true
+  - type: textarea
+    id: result
+    attributes:
+      label: Outcome
+      placeholder: Tell us what went wrong
+      value: |
+        #### What did you expect?
+
+        #### What happened instead?
+        
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Sweyer version
+      description: You can find the version information in App Menu -> Settings at the bottom. If you compiled the app yourself, please specify the commit here.
+      placeholder: e.g. 1.0.7
+    validations:
+      required: true
+  - type: input
+    id: android-version
+    attributes:
+      label: Android version
+      description: The Andorid version of your device. You can leave this empty if you are sure that it's not important, if you are unsure please specify. 
+      placeholder: e.g. Android 12 or Android Snow Cone
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -10,12 +10,6 @@ body:
     attributes:
       label: Suggestion
       description: Please feel welcome to include screenshots or sketches.
-      placeholder: Tell us what you would like to do!
-      value: |
-        #### What would you like to do?
-
-        #### Why would you like to do it?
-
-        #### How would you like to achieve it?
+      placeholder: I would like to ...
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,10 +1,10 @@
-name: Enhancement request
-description: Do you have a suggestion or feature request?
+name: Feature request
+description: Do you have a suggestion?
 labels: [enhancement]
 body:
   - type: markdown
     attributes:
-      value: Thank you for taking the time to propose a new feature or make a suggestion.
+      value: Thank you for taking the time to make a suggestion!
   - type: textarea
     id: suggestion
     attributes:
@@ -17,6 +17,5 @@ body:
         #### Why would you like to do it?
 
         #### How would you like to achieve it?
-        
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,22 @@
+name: Enhancement request
+description: Do you have a suggestion or feature request?
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for taking the time to propose a new feature or make a suggestion.
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggestion
+      description: Please feel welcome to include screenshots or sketches.
+      placeholder: Tell us what you would like to do!
+      value: |
+        #### What would you like to do?
+
+        #### Why would you like to do it?
+
+        #### How would you like to achieve it?
+        
+    validations:
+      required: true


### PR DESCRIPTION
This adds two issue templates, which should help in writing issues and also automatically label the issue.
This is how it will look:

![Issue template selection screen](https://user-images.githubusercontent.com/6966049/169138710-654743a5-25ab-4bfd-ba32-5a778f3113c5.png)
Notice that there is still an option to create a raw issue, if the templates don't fit. (The edit template options is only visible for admins.)

* Bug report:
  ![Bug report template](https://user-images.githubusercontent.com/6966049/169139088-54c6e5c3-85c2-440a-af55-4ccce8dbea76.png)
* Enhancement request:
  ![Enhancement request template](https://user-images.githubusercontent.com/6966049/169139277-2ff30540-8538-4656-8df0-2aa4c0178b30.png)
