### PR TITLE
Make the patch check of Codecov informational as well

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,6 @@ coverage:
     project:
       default:
         informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
As per the [Codecov documentation](https://docs.codecov.com/docs/common-recipe-list#set-non-blocking-status-checks), the patch and project check apparently need to be configured separately.

This will prevent the `codecov/patch` to fail for pull requests which decrease the code coverage.