### PR TITLE
Fix opening the search page from a search query

### DIFF
--- a/lib/routes/home_route/home_route.dart
+++ b/lib/routes/home_route/home_route.dart
@@ -96,23 +96,26 @@ class HomeState extends State<Home> {
   Widget build(BuildContext context) {
     return Scaffold(
       resizeToAvoidBottomInset: false,
-      body: Stack(
-        children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.only(bottom: kSongTileHeight),
-            child: Router<HomeRoutes>(
-              routerDelegate: router,
-              routeInformationParser: HomeRouteInformationParser(),
-              routeInformationProvider: HomeRouteInformationProvider(),
-              backButtonDispatcher: HomeRouteBackButtonDispatcher(
-                Router.of(context).backButtonDispatcher!,
+      body: RouterDelegateProvider<HomeRouter>(
+        delegate: router,
+        child: Stack(
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.only(bottom: kSongTileHeight),
+              child: Router<HomeRoutes>(
+                routerDelegate: router,
+                routeInformationParser: HomeRouteInformationParser(),
+                routeInformationProvider: HomeRouteInformationProvider(),
+                backButtonDispatcher: HomeRouteBackButtonDispatcher(
+                  Router.of(context).backButtonDispatcher!,
+                ),
               ),
             ),
-          ),
-          const PlayerRoute(),
-          Overlay(key: overlayKey),
-          const DrawerWidget(),
-        ],
+            const PlayerRoute(),
+            Overlay(key: overlayKey),
+            const DrawerWidget(),
+          ],
+        ),
       ),
     );
   }

--- a/lib/routes/routes.dart
+++ b/lib/routes/routes.dart
@@ -656,11 +656,14 @@ class HomeRouter extends RouterDelegate<HomeRoutes<Object?>>
         throw UnimplementedError();
       }
     }
-    return Navigator(
-      key: navigatorKey,
-      observers: [observer],
-      onPopPage: _handlePopPage,
-      pages: pages,
+    return RouterDelegateProvider<HomeRouter>(
+      delegate: this,
+      child: Navigator(
+        key: navigatorKey,
+        observers: [observer],
+        onPopPage: _handlePopPage,
+        pages: pages,
+      ),
     );
   }
 }

--- a/lib/routes/routes.dart
+++ b/lib/routes/routes.dart
@@ -472,11 +472,11 @@ class HomeRouter extends RouterDelegate<HomeRoutes<Object?>>
   static HomeRouter get instance => _instance!;
 
   static HomeRouter of(BuildContext context) {
-    return _RouterDelegateProvider.maybeOf<HomeRouter>(context)!;
+    return RouterDelegateProvider.maybeOf<HomeRouter>(context)!;
   }
 
   static HomeRouter? maybeOf(BuildContext context) {
-    return _RouterDelegateProvider.maybeOf<HomeRouter>(context);
+    return RouterDelegateProvider.maybeOf<HomeRouter>(context);
   }
 
   @override
@@ -656,14 +656,11 @@ class HomeRouter extends RouterDelegate<HomeRoutes<Object?>>
         throw UnimplementedError();
       }
     }
-    return _RouterDelegateProvider<HomeRouter>(
-      delegate: this,
-      child: Navigator(
-        key: navigatorKey,
-        observers: [observer],
-        onPopPage: _handlePopPage,
-        pages: pages,
-      ),
+    return Navigator(
+      key: navigatorKey,
+      observers: [observer],
+      onPopPage: _handlePopPage,
+      pages: pages,
     );
   }
 }
@@ -686,8 +683,8 @@ class HomeRouteBackButtonDispatcher extends ChildBackButtonDispatcher {
   }
 }
 
-class _RouterDelegateProvider<T extends RouterDelegate> extends InheritedWidget {
-  _RouterDelegateProvider({
+class RouterDelegateProvider<T extends RouterDelegate> extends InheritedWidget {
+  RouterDelegateProvider({
     Key? key,
     required this.delegate,
     required Widget child,
@@ -696,8 +693,8 @@ class _RouterDelegateProvider<T extends RouterDelegate> extends InheritedWidget 
   final T delegate;
 
   static T? maybeOf<T extends RouterDelegate>(BuildContext context) {
-    return (context.getElementForInheritedWidgetOfExactType<_RouterDelegateProvider<T>>()?.widget 
-              as _RouterDelegateProvider<T>?)?.delegate;
+    return (context.getElementForInheritedWidgetOfExactType<RouterDelegateProvider<T>>()?.widget 
+              as RouterDelegateProvider<T>?)?.delegate;
   }
 
   @override

--- a/test/routes/player_route_test.dart
+++ b/test/routes/player_route_test.dart
@@ -49,7 +49,6 @@ void main() {
   group('queue screen', () {
     testWidgets('can open by swiping to left', (WidgetTester tester) async {
       await tester.runAppTest(() async {
-        QueueControl.instance.resetQueue();
         // Expand the route
         await expandPlayerRoute(tester);
 
@@ -114,7 +113,6 @@ void main() {
 
   testWidgets('shuffle button works', (WidgetTester tester) async {
     await tester.runAppTest(() async {
-      QueueControl.instance.resetQueue();
       // Expand the route
       await expandPlayerRoute(tester);
 

--- a/test/routes/player_route_test.dart
+++ b/test/routes/player_route_test.dart
@@ -12,6 +12,13 @@ void main() {
     await tester.pumpAndSettle();
     expect(playerRouteController.value, 1.0);
   }
+  
+  /// Navigate to the queue screen in the player route.
+  Future<void> openQueueScreen(WidgetTester tester) async {
+    await expandPlayerRoute(tester);
+    await tester.flingFrom(Offset.zero, const Offset(-400.0, 0.0), 1000.0);
+    await tester.pumpAndSettle();
+  }
 
   testWidgets('can expand/collapse by tapping the button', (WidgetTester tester) async {
     await tester.runAppTest(() async {
@@ -39,15 +46,43 @@ void main() {
     });
   });
 
-  testWidgets('can open queue screen by swiping to left', (WidgetTester tester) async {
-    await tester.runAppTest(() async {
-      // Expand the route
-      await expandPlayerRoute(tester);
+  group('queue screen', () {
+    testWidgets('can open by swiping to left', (WidgetTester tester) async {
+      await tester.runAppTest(() async {
+        QueueControl.instance.resetQueue();
+        // Expand the route
+        await expandPlayerRoute(tester);
 
-      expect(find.text(l10n.upNext), findsNothing);
-      await tester.flingFrom(Offset.zero, const Offset(-400.0, 0.0), 1000.0);
-      await tester.pumpAndSettle();
-      expect(find.text(l10n.upNext), findsOneWidget);
+        expect(find.text(l10n.upNext), findsNothing);
+        await tester.flingFrom(Offset.zero, const Offset(-400.0, 0.0), 1000.0);
+        await tester.pumpAndSettle();
+        expect(find.text(l10n.upNext), findsOneWidget);
+        expect(find.text(l10n.allTracks), findsOneWidget);
+      });
+    });
+
+    testWidgets('displays search query correctly', (WidgetTester tester) async {
+      const query = 'Query';
+      await tester.runAppTest(() async {
+        QueueControl.instance.setSearchedQueue(query, [songWith()]);
+        await openQueueScreen(tester);
+        expect(find.text(l10n.upNext), findsOneWidget);
+        expect(find.text(l10n.foundByQuery('"$query"'), findRichText: true), findsOneWidget);
+      });
+    });
+
+    testWidgets('Allows to open the search query from the title', (WidgetTester tester) async {
+      const query = 'Query';
+      await tester.runAppTest(() async {
+        QueueControl.instance.setSearchedQueue(query, [songWith()]);
+        await openQueueScreen(tester);
+        await tester.tap(find.byIcon(Icons.chevron_right_rounded));
+        await tester.pumpAndSettle();
+        expect(find.byType(SearchRoute), findsOneWidget);
+        final queryInput = find.byType(TextField).evaluate().first.widget as TextField;
+        expect(queryInput.controller!.text, query);
+        expect(queryInput.focusNode!.hasFocus, false);
+      });
     });
   });
 
@@ -76,6 +111,7 @@ void main() {
 
   testWidgets('shuffle button works', (WidgetTester tester) async {
     await tester.runAppTest(() async {
+      QueueControl.instance.resetQueue();
       // Expand the route
       await expandPlayerRoute(tester);
 

--- a/test/routes/player_route_test.dart
+++ b/test/routes/player_route_test.dart
@@ -79,9 +79,12 @@ void main() {
         await tester.tap(find.byIcon(Icons.chevron_right_rounded));
         await tester.pumpAndSettle();
         expect(find.byType(SearchRoute), findsOneWidget);
-        final queryInput = find.byType(TextField).evaluate().first.widget as TextField;
-        expect(queryInput.controller!.text, query);
-        expect(queryInput.focusNode!.hasFocus, false);
+        final queryTextField = tester.widget<TextField>(find.descendant(
+          of: find.byType(SearchRoute),
+          matching: find.byType(TextField),
+        ));
+        expect(queryTextField.controller!.text, query);
+        expect(queryTextField.focusNode!.hasFocus, false);
       });
     });
   });


### PR DESCRIPTION
Fixes #42 by adding an additional `RouterDelegateProvider` higher up in the widget tree so the `PlayerRoute` is able to access the `HomeRouter`.
The `HomeRouter.of(context)` call in `showSongsSearch` can now find the `RouterDelegateProvider`.

![Search query title click behavior](https://user-images.githubusercontent.com/6966049/172060126-b9c17166-3d60-4d02-bc44-d5d48ec11a3f.gif)
