### PR TITLE
Add a link to the Google Play store entry to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 An open-source non-commercial music player built with Flutter
 
-[<img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" alt="Get it on Google Play" height="60px">](https://play.google.com/store/apps/details?id=com.nt4f04und.sweyer)
-
 For the time being it's Android-only and I have no plans to support other platforms, however
 I don't mind accepting someone's PR tweaking this
+
+[<img height="90px" alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png'/>](https://play.google.com/store/apps/details?id=com.nt4f04und.sweyer)
 
 <img alt="" src="./static_assets/readme/feature_graphic.png"></div>
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 An open-source non-commercial music player built with Flutter
 
+[<img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" alt="Get it on Google Play" height="60px">](https://play.google.com/store/apps/details?id=com.nt4f04und.sweyer)
+
 For the time being it's Android-only and I have no plans to support other platforms, however
 I don't mind accepting someone's PR tweaking this
 


### PR DESCRIPTION
I think it would be good for everyone who's stumbling across this repo in search of a music player to have a quick link to the Google Play store.

This is how it looks:
![Readme file with new link](https://user-images.githubusercontent.com/6966049/174162089-149b74b3-431c-4372-ab2f-1ecfa9b6135f.png)
