### PR TITLE
Fix layout issues caused by not accounting for the textScaleFactor

### DIFF
--- a/lib/routes/home_route/artist_route.dart
+++ b/lib/routes/home_route/artist_route.dart
@@ -259,7 +259,7 @@ class _ArtistRouteState extends State<ArtistRoute> with TickerProviderStateMixin
           /// always be fully scrollable, even if there's not enough content for that.
           var additionalHeight = constraints.maxHeight - //
               _fullAppBarHeight - //
-              kSongTileHeight * math.min(songs.length, 5) - //
+              kSongTileHeight(mediaQuery.textScaleFactor) * math.min(songs.length, 5) - //
               48.0;
 
           if (albums.isNotEmpty) {

--- a/lib/routes/home_route/artist_route.dart
+++ b/lib/routes/home_route/artist_route.dart
@@ -259,7 +259,7 @@ class _ArtistRouteState extends State<ArtistRoute> with TickerProviderStateMixin
           /// always be fully scrollable, even if there's not enough content for that.
           var additionalHeight = constraints.maxHeight - //
               _fullAppBarHeight - //
-              kSongTileHeight(mediaQuery.textScaleFactor) * math.min(songs.length, 5) - //
+              kSongTileHeight(context) * math.min(songs.length, 5) - //
               48.0;
 
           if (albums.isNotEmpty) {

--- a/lib/routes/home_route/home_route.dart
+++ b/lib/routes/home_route/home_route.dart
@@ -121,7 +121,7 @@ class HomeState extends State<Home> {
           child: Stack(
             children: <Widget>[
               Padding(
-                padding: const EdgeInsets.only(bottom: kSongTileHeight),
+                padding: EdgeInsets.only(bottom: kSongTileHeight(MediaQuery.of(context).textScaleFactor)),
                 child: Router<HomeRoutes>(
                   routerDelegate: router,
                   routeInformationParser: HomeRouteInformationParser(),

--- a/lib/routes/home_route/home_route.dart
+++ b/lib/routes/home_route/home_route.dart
@@ -121,7 +121,7 @@ class HomeState extends State<Home> {
           child: Stack(
             children: <Widget>[
               Padding(
-                padding: EdgeInsets.only(bottom: kSongTileHeight(MediaQuery.of(context).textScaleFactor)),
+                padding: EdgeInsets.only(bottom: kSongTileHeight(context)),
                 child: Router<HomeRoutes>(
                   routerDelegate: router,
                   routeInformationParser: HomeRouteInformationParser(),

--- a/lib/routes/home_route/persistent_queue_route.dart
+++ b/lib/routes/home_route/persistent_queue_route.dart
@@ -591,14 +591,16 @@ class _PersistentQueueRouteState extends State<PersistentQueueRoute> with Select
             final mediaQuery = MediaQuery.of(context);
             final showAddSongsAction = isPlaylist && !selectionRoute;
 
+            final songTileHeight = kSongTileHeight(mediaQuery.textScaleFactor);
+
             /// The height to add at the end of the scroll view to make the top info part of the route
             /// always be fully scrollable, even if there's not enough items for that.
             final additionalHeight = constraints.maxHeight -
                 _appBarHeight - //
                 AppBarBorder.height - //
                 mediaQuery.padding.top - //
-                kSongTileHeight * songs.length - //
-                (showAddSongsAction ? kSongTileHeight : 0.0); // InListContentAction
+                songTileHeight * songs.length - //
+                (showAddSongsAction ? songTileHeight : 0.0); // InListContentAction
 
             return ScrollConfiguration(
               behavior: const GlowlessScrollBehavior(),

--- a/lib/routes/home_route/persistent_queue_route.dart
+++ b/lib/routes/home_route/persistent_queue_route.dart
@@ -591,7 +591,7 @@ class _PersistentQueueRouteState extends State<PersistentQueueRoute> with Select
             final mediaQuery = MediaQuery.of(context);
             final showAddSongsAction = isPlaylist && !selectionRoute;
 
-            final songTileHeight = kSongTileHeight(mediaQuery.textScaleFactor);
+            final songTileHeight = kSongTileHeight(context);
 
             /// The height to add at the end of the scroll view to make the top info part of the route
             /// always be fully scrollable, even if there's not enough items for that.

--- a/lib/routes/home_route/player_route.dart
+++ b/lib/routes/home_route/player_route.dart
@@ -249,7 +249,7 @@ class _QueueTabState extends State<_QueueTab> with SelectionHandlerMixin {
   /// If optional [index] is provided - scrolls to it.
   Future<void> scrollToSong([int? index]) async {
     index ??= PlaybackControl.instance.currentSongIndex;
-    final extent = index * kSongTileHeight;
+    final extent = index * kSongTileHeight(MediaQuery.of(context).textScaleFactor);
     final pixels = scrollController.position.pixels;
     final min = scrollController.position.minScrollExtent;
     final max = scrollController.position.maxScrollExtent;
@@ -280,7 +280,7 @@ class _QueueTabState extends State<_QueueTab> with SelectionHandlerMixin {
     index ??= PlaybackControl.instance.currentSongIndex;
     final min = scrollController.position.minScrollExtent;
     final max = scrollController.position.maxScrollExtent;
-    scrollController.jumpTo((index * kSongTileHeight).clamp(min, max));
+    scrollController.jumpTo((index * kSongTileHeight(MediaQuery.of(context).textScaleFactor)).clamp(min, max));
   }
 
   /// Jump to song when changing tab to main.
@@ -484,7 +484,8 @@ class _QueueTabState extends State<_QueueTab> with SelectionHandlerMixin {
     final l10n = getl10n(context);
     final theme = Theme.of(context);
     final origin = QueueControl.instance.state.origin;
-    final topScreenPadding = MediaQuery.of(context).padding.top;
+    final mediaQuery = MediaQuery.of(context);
+    final topScreenPadding = mediaQuery.padding.top;
     final appBarHeightWithPadding = appBarHeight + topScreenPadding;
     final fadeAnimation = CurvedAnimation(
       curve: const Interval(0.6, 1.0),
@@ -652,7 +653,7 @@ class _QueueTabState extends State<_QueueTab> with SelectionHandlerMixin {
                   selectionController: widget.selectionController,
                   padding: EdgeInsets.only(
                     top: 4.0,
-                    bottom: value == null ? 0.0 : kSongTileHeight + 4.0,
+                    bottom: value == null ? 0.0 : kSongTileHeight(mediaQuery.textScaleFactor) + 4.0,
                   ),
                   songTileVariant:
                       QueueControl.instance.state.origin is Album ? SongTileVariant.number : SongTileVariant.albumArt,

--- a/lib/routes/home_route/player_route.dart
+++ b/lib/routes/home_route/player_route.dart
@@ -123,7 +123,7 @@ class _PlayerRouteState extends State<PlayerRoute> with SingleTickerProviderStat
     final screenHeight = mediaQuery.size.height;
     return Slidable(
       controller: controller,
-      start: 1.0 - TrackPanel.height(mediaQuery.textScaleFactor) / screenHeight,
+      start: 1.0 - TrackPanel.height(context) / screenHeight,
       end: 0.0,
       direction: slideDirection,
       barrier: Container(
@@ -249,7 +249,7 @@ class _QueueTabState extends State<_QueueTab> with SelectionHandlerMixin {
   /// If optional [index] is provided - scrolls to it.
   Future<void> scrollToSong([int? index]) async {
     index ??= PlaybackControl.instance.currentSongIndex;
-    final extent = index * kSongTileHeight(MediaQuery.of(context).textScaleFactor);
+    final extent = index * kSongTileHeight(context);
     final pixels = scrollController.position.pixels;
     final min = scrollController.position.minScrollExtent;
     final max = scrollController.position.maxScrollExtent;
@@ -280,7 +280,7 @@ class _QueueTabState extends State<_QueueTab> with SelectionHandlerMixin {
     index ??= PlaybackControl.instance.currentSongIndex;
     final min = scrollController.position.minScrollExtent;
     final max = scrollController.position.maxScrollExtent;
-    scrollController.jumpTo((index * kSongTileHeight(MediaQuery.of(context).textScaleFactor)).clamp(min, max));
+    scrollController.jumpTo((index * kSongTileHeight(context)).clamp(min, max));
   }
 
   /// Jump to song when changing tab to main.
@@ -653,7 +653,7 @@ class _QueueTabState extends State<_QueueTab> with SelectionHandlerMixin {
                   selectionController: widget.selectionController,
                   padding: EdgeInsets.only(
                     top: 4.0,
-                    bottom: value == null ? 0.0 : kSongTileHeight(mediaQuery.textScaleFactor) + 4.0,
+                    bottom: value == null ? 0.0 : kSongTileHeight(context) + 4.0,
                   ),
                   songTileVariant:
                       QueueControl.instance.state.origin is Album ? SongTileVariant.number : SongTileVariant.albumArt,
@@ -702,7 +702,7 @@ class _MainTabState extends State<_MainTab> {
           elevation: 0.0,
           backgroundColor: Colors.transparent,
           toolbarHeight: math.max(
-            TrackPanel.height(mediaQuery.textScaleFactor) - mediaQuery.padding.top,
+            TrackPanel.height(context) - mediaQuery.padding.top,
             theme.appBarTheme.toolbarHeight ?? kToolbarHeight,
           ),
           leading: FadeTransition(

--- a/lib/routes/routes.dart
+++ b/lib/routes/routes.dart
@@ -545,10 +545,11 @@ class HomeRouter extends RouterDelegate<HomeRoutes<Object?>>
     LocalKey key,
     StackFadeRouteTransitionSettings transitionSettings,
     Widget child,
+    double textScaleFactor,
   ) {
     if (selectionRoute) {
       child = Padding(
-        padding: const EdgeInsets.only(bottom: kSongTileHeight),
+        padding: EdgeInsets.only(bottom: kSongTileHeight(textScaleFactor)),
         child: child,
       );
     }
@@ -559,10 +560,10 @@ class HomeRouter extends RouterDelegate<HomeRoutes<Object?>>
     );
   }
 
-  Widget _buildChild(Widget child) {
+  Widget _buildChild(Widget child, double textScaleFactor) {
     if (selectionRoute) {
       child = Padding(
-        padding: const EdgeInsets.only(bottom: kSongTileHeight),
+        padding: EdgeInsets.only(bottom: kSongTileHeight(textScaleFactor)),
         child: child,
       );
     }
@@ -573,6 +574,7 @@ class HomeRouter extends RouterDelegate<HomeRoutes<Object?>>
   Widget build(BuildContext context) {
     final transitionSettings = AppRouter.instance.transitionSettings;
     final pages = <Page<void>>[];
+    double textScaleFactor = MediaQuery.of(context).textScaleFactor;
 
     for (int i = 0; i < _routes.length; i++) {
       LocalKey _buildContentKey(_Routes route, Content content) {
@@ -585,6 +587,7 @@ class HomeRouter extends RouterDelegate<HomeRoutes<Object?>>
           HomeRoutes.tabs.uniqueKey,
           transitionSettings.grey,
           TabsRoute(key: tabsRouteKey),
+          textScaleFactor,
         ));
       } else if (route.hasSameLocation(HomeRoutes.album)) {
         final arguments = route.arguments! as PersistentQueueArguments<Album>;
@@ -592,6 +595,7 @@ class HomeRouter extends RouterDelegate<HomeRoutes<Object?>>
           _buildContentKey(HomeRoutes.album, arguments.queue),
           transitionSettings.greyDismissible,
           PersistentQueueRoute(arguments: arguments),
+          textScaleFactor,
         ));
       } else if (route.hasSameLocation(HomeRoutes.playlist)) {
         final arguments = route.arguments! as PersistentQueueArguments<Playlist>;
@@ -599,6 +603,7 @@ class HomeRouter extends RouterDelegate<HomeRoutes<Object?>>
           _buildContentKey(route, arguments.queue),
           transitionSettings.greyDismissible,
           PersistentQueueRoute(arguments: arguments),
+          textScaleFactor,
         ));
       } else if (route.hasSameLocation(HomeRoutes.artist)) {
         final arguments = route.arguments! as Artist;
@@ -606,6 +611,7 @@ class HomeRouter extends RouterDelegate<HomeRoutes<Object?>>
           _buildContentKey(route, arguments),
           transitionSettings.greyDismissible,
           ArtistRoute(artist: arguments),
+          textScaleFactor,
         ));
       } else if (route.hasSameLocation(HomeRoutes.artistContent)) {
         final arguments = route.arguments! as ArtistContentArguments;
@@ -621,12 +627,13 @@ class HomeRouter extends RouterDelegate<HomeRoutes<Object?>>
           ValueKey('${HomeRoutes.artistContent.location}/${arguments.artist.id}_$i'),
           transitionSettings.greyDismissible,
           actualRoute,
+          textScaleFactor,
         ));
       } else if (route.hasSameLocation(HomeRoutes.search)) {
         final arguments = route.arguments! as SearchArguments;
         pages.add(SearchPage(
           key: ValueKey('${HomeRoutes.search.location}/$i'),
-          child: _buildChild(SearchRoute(delegate: arguments._delegate)),
+          child: _buildChild(SearchRoute(delegate: arguments._delegate), textScaleFactor),
           transitionSettings: transitionSettings.grey,
         ));
       } else {

--- a/lib/routes/routes.dart
+++ b/lib/routes/routes.dart
@@ -542,14 +542,14 @@ class HomeRouter extends RouterDelegate<HomeRoutes<Object?>>
   }
 
   Page<void> _buildPage(
+    BuildContext context,
     LocalKey key,
     StackFadeRouteTransitionSettings transitionSettings,
     Widget child,
-    double textScaleFactor,
   ) {
     if (selectionRoute) {
       child = Padding(
-        padding: EdgeInsets.only(bottom: kSongTileHeight(textScaleFactor)),
+        padding: EdgeInsets.only(bottom: kSongTileHeight(context)),
         child: child,
       );
     }
@@ -560,10 +560,10 @@ class HomeRouter extends RouterDelegate<HomeRoutes<Object?>>
     );
   }
 
-  Widget _buildChild(Widget child, double textScaleFactor) {
+  Widget _buildChild(BuildContext context, Widget child) {
     if (selectionRoute) {
       child = Padding(
-        padding: EdgeInsets.only(bottom: kSongTileHeight(textScaleFactor)),
+        padding: EdgeInsets.only(bottom: kSongTileHeight(context)),
         child: child,
       );
     }
@@ -574,7 +574,6 @@ class HomeRouter extends RouterDelegate<HomeRoutes<Object?>>
   Widget build(BuildContext context) {
     final transitionSettings = AppRouter.instance.transitionSettings;
     final pages = <Page<void>>[];
-    double textScaleFactor = MediaQuery.of(context).textScaleFactor;
 
     for (int i = 0; i < _routes.length; i++) {
       LocalKey _buildContentKey(_Routes route, Content content) {
@@ -584,34 +583,34 @@ class HomeRouter extends RouterDelegate<HomeRoutes<Object?>>
       final route = _routes[i];
       if (route.hasSameLocation(HomeRoutes.tabs)) {
         pages.add(_buildPage(
+          context,
           HomeRoutes.tabs.uniqueKey,
           transitionSettings.grey,
           TabsRoute(key: tabsRouteKey),
-          textScaleFactor,
         ));
       } else if (route.hasSameLocation(HomeRoutes.album)) {
         final arguments = route.arguments! as PersistentQueueArguments<Album>;
         pages.add(_buildPage(
+          context,
           _buildContentKey(HomeRoutes.album, arguments.queue),
           transitionSettings.greyDismissible,
           PersistentQueueRoute(arguments: arguments),
-          textScaleFactor,
         ));
       } else if (route.hasSameLocation(HomeRoutes.playlist)) {
         final arguments = route.arguments! as PersistentQueueArguments<Playlist>;
         pages.add(_buildPage(
+          context,
           _buildContentKey(route, arguments.queue),
           transitionSettings.greyDismissible,
           PersistentQueueRoute(arguments: arguments),
-          textScaleFactor,
         ));
       } else if (route.hasSameLocation(HomeRoutes.artist)) {
         final arguments = route.arguments! as Artist;
         pages.add(_buildPage(
+          context,
           _buildContentKey(route, arguments),
           transitionSettings.greyDismissible,
           ArtistRoute(artist: arguments),
-          textScaleFactor,
         ));
       } else if (route.hasSameLocation(HomeRoutes.artistContent)) {
         final arguments = route.arguments! as ArtistContentArguments;
@@ -624,16 +623,16 @@ class HomeRouter extends RouterDelegate<HomeRoutes<Object?>>
           throw ArgumentError();
         }
         pages.add(_buildPage(
+          context,
           ValueKey('${HomeRoutes.artistContent.location}/${arguments.artist.id}_$i'),
           transitionSettings.greyDismissible,
           actualRoute,
-          textScaleFactor,
         ));
       } else if (route.hasSameLocation(HomeRoutes.search)) {
         final arguments = route.arguments! as SearchArguments;
         pages.add(SearchPage(
           key: ValueKey('${HomeRoutes.search.location}/$i'),
-          child: _buildChild(SearchRoute(delegate: arguments._delegate), textScaleFactor),
+          child: _buildChild(context, SearchRoute(delegate: arguments._delegate)),
           transitionSettings: transitionSettings.grey,
         ));
       } else {

--- a/lib/widgets/artist.dart
+++ b/lib/widgets/artist.dart
@@ -17,12 +17,15 @@ class ArtistWidget extends StatelessWidget {
   final String? trailingText;
   final TextOverflow overflow;
   final TextStyle? textStyle;
+  
+  /// The default [TextStyle] used for text in this widget from the [theme].
+  static TextStyle defaultTextStyle(ThemeData theme) => theme.textTheme.subtitle2!;
 
   @override
   Widget build(BuildContext context) {
     final l10n = getl10n(context);
     final localizedArtist = ContentUtils.localizedArtist(artist, l10n);
-    final style = Theme.of(context).textTheme.subtitle2!.merge(textStyle);
+    final style = defaultTextStyle(Theme.of(context)).merge(textStyle);
     return Row(
       mainAxisSize: MainAxisSize.min,
       mainAxisAlignment: MainAxisAlignment.start,

--- a/lib/widgets/bottom_track_panel.dart
+++ b/lib/widgets/bottom_track_panel.dart
@@ -119,7 +119,7 @@ class TrackPanel extends StatelessWidget {
   }
 
   /// The height of this widget given a [textScaleFactor].
-  static double height(double textScaleFactor) => kSongTileHeight * math.max(0.95, textScaleFactor);
+  static double height(double textScaleFactor) => kSongTileHeight(textScaleFactor);
 }
 
 class RotatingAlbumArtWithProgress extends StatefulWidget {

--- a/lib/widgets/bottom_track_panel.dart
+++ b/lib/widgets/bottom_track_panel.dart
@@ -52,7 +52,7 @@ class TrackPanel extends StatelessWidget {
                 child: Material(
                   color: Colors.transparent,
                   child: Container(
-                    height: TrackPanel.height(textScaleFactor),
+                    height: TrackPanel.height(context),
                     padding: const EdgeInsets.only(
                       left: 16.0,
                       right: 16.0,
@@ -118,8 +118,8 @@ class TrackPanel extends StatelessWidget {
     );
   }
 
-  /// The height of this widget given a [textScaleFactor].
-  static double height(double textScaleFactor) => kSongTileHeight(textScaleFactor);
+  /// The height of this widget given a [context].
+  static double height(BuildContext context) => kSongTileHeight(context);
 }
 
 class RotatingAlbumArtWithProgress extends StatefulWidget {

--- a/lib/widgets/content_list_view/content_list_view.dart
+++ b/lib/widgets/content_list_view/content_list_view.dart
@@ -150,6 +150,7 @@ class ContentListView<T extends Content> extends StatelessWidget {
           SliverPadding(
             padding: padding,
             sliver: sliver(
+              context: context,
               contentType: contentType,
               list: list,
               itemBuilder: itemBuilder,
@@ -183,6 +184,7 @@ class ContentListView<T extends Content> extends StatelessWidget {
   ///  * [reorderableSliver] which creates a reorderable sliver
   @factory
   static MultiSliver sliver<T extends Content>({
+    required BuildContext context,
     Key? key,
     required ContentType<T> contentType,
     required List<T> list,
@@ -205,7 +207,7 @@ class ContentListView<T extends Content> extends StatelessWidget {
       children: [
         if (leading != null) leading,
         SliverFixedExtentList(
-          itemExtent: ContentTile.getHeight(contentType),
+          itemExtent: ContentTile.getHeight(contentType, MediaQuery.of(context).textScaleFactor),
           delegate: SliverChildBuilderDelegate(
             (context, index) {
               final item = list[index];

--- a/lib/widgets/content_list_view/content_list_view.dart
+++ b/lib/widgets/content_list_view/content_list_view.dart
@@ -150,7 +150,6 @@ class ContentListView<T extends Content> extends StatelessWidget {
           SliverPadding(
             padding: padding,
             sliver: sliver(
-              context: context,
               contentType: contentType,
               list: list,
               itemBuilder: itemBuilder,
@@ -184,7 +183,6 @@ class ContentListView<T extends Content> extends StatelessWidget {
   ///  * [reorderableSliver] which creates a reorderable sliver
   @factory
   static MultiSliver sliver<T extends Content>({
-    required BuildContext context,
     Key? key,
     required ContentType<T> contentType,
     required List<T> list,
@@ -206,39 +204,41 @@ class ContentListView<T extends Content> extends StatelessWidget {
     return MultiSliver(
       children: [
         if (leading != null) leading,
-        SliverFixedExtentList(
-          itemExtent: ContentTile.getHeight(contentType, MediaQuery.of(context).textScaleFactor),
-          delegate: SliverChildBuilderDelegate(
-            (context, index) {
-              final item = list[index];
-              final child = ContentTile(
-                contentType: contentType,
-                content: item,
-                selectionIndex: selectionIndexMapper != null ? selectionIndexMapper(index) : index,
-                selected: selectedTest != null
-                    ? selectedTest(index)
-                    : selectionController?.data.contains(SelectionEntry<T>.fromContent(
-                          content: item,
-                          index: index,
-                          context: context,
-                        )) ??
-                        false,
-                longPressSelectionGestureEnabled: longPressSelectionGestureEnabledTest?.call(index) ?? true,
-                handleTapInSelection: handleTapInSelectionTest?.call(index) ?? true,
-                selectionController: selectionController,
-                trailing: itemTrailingBuilder?.call(context, index),
-                current: currentTest?.call(index),
-                onTap: onItemTap == null ? null : () => onItemTap(index),
-                backgroundColor: backgroundColorBuilder == null ? Colors.transparent : backgroundColorBuilder(index),
-                enableDefaultOnTap: enableDefaultOnTap,
-                songTileVariant: songTileVariant,
-                songTileClickBehavior: songTileClickBehavior,
-              );
-              return itemBuilder?.call(context, index, child) ?? child;
-            },
-            childCount: list.length,
-          ),
-        ),
+        Builder(builder: (context) {
+          return SliverFixedExtentList(
+            itemExtent: ContentTile.getHeight(contentType, context),
+            delegate: SliverChildBuilderDelegate(
+              (context, index) {
+                final item = list[index];
+                final child = ContentTile(
+                  contentType: contentType,
+                  content: item,
+                  selectionIndex: selectionIndexMapper != null ? selectionIndexMapper(index) : index,
+                  selected: selectedTest != null
+                      ? selectedTest(index)
+                      : selectionController?.data.contains(SelectionEntry<T>.fromContent(
+                            content: item,
+                            index: index,
+                            context: context,
+                          )) ??
+                          false,
+                  longPressSelectionGestureEnabled: longPressSelectionGestureEnabledTest?.call(index) ?? true,
+                  handleTapInSelection: handleTapInSelectionTest?.call(index) ?? true,
+                  selectionController: selectionController,
+                  trailing: itemTrailingBuilder?.call(context, index),
+                  current: currentTest?.call(index),
+                  onTap: onItemTap == null ? null : () => onItemTap(index),
+                  backgroundColor: backgroundColorBuilder == null ? Colors.transparent : backgroundColorBuilder(index),
+                  enableDefaultOnTap: enableDefaultOnTap,
+                  songTileVariant: songTileVariant,
+                  songTileClickBehavior: songTileClickBehavior,
+                );
+                return itemBuilder?.call(context, index, child) ?? child;
+              },
+              childCount: list.length,
+            ),
+          );
+        }),
       ],
     );
   }

--- a/lib/widgets/content_list_view/content_tile.dart
+++ b/lib/widgets/content_list_view/content_tile.dart
@@ -40,10 +40,10 @@ class ContentTile<T extends Content> extends StatelessWidget {
   final bool handleTapInSelection;
   final ContentSelectionController? selectionController;
 
-  static double getHeight(ContentType contentType, double textScaleFactor) {
+  static double getHeight(ContentType contentType, BuildContext context) {
     switch (contentType) {
       case ContentType.song:
-        return kSongTileHeight(textScaleFactor);
+        return kSongTileHeight(context);
       case ContentType.album:
         return kPersistentQueueTileHeight;
       case ContentType.playlist:

--- a/lib/widgets/content_list_view/content_tile.dart
+++ b/lib/widgets/content_list_view/content_tile.dart
@@ -40,10 +40,10 @@ class ContentTile<T extends Content> extends StatelessWidget {
   final bool handleTapInSelection;
   final ContentSelectionController? selectionController;
 
-  static double getHeight(ContentType contentType) {
+  static double getHeight(ContentType contentType, double textScaleFactor) {
     switch (contentType) {
       case ContentType.song:
-        return kSongTileHeight;
+        return kSongTileHeight(textScaleFactor);
       case ContentType.album:
         return kPersistentQueueTileHeight;
       case ContentType.playlist:

--- a/lib/widgets/content_list_view/in_list_action.dart
+++ b/lib/widgets/content_list_view/in_list_action.dart
@@ -105,7 +105,7 @@ class _InListContentActionState extends State<InListContentAction> with SingleTi
           onTap: widget.onTap,
           child: Container(
             padding: EdgeInsets.symmetric(horizontal: widget.horizontalPadding),
-            height: kSongTileHeight(MediaQuery.of(context).textScaleFactor),
+            height: kSongTileHeight(context),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.center,
               mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/widgets/content_list_view/in_list_action.dart
+++ b/lib/widgets/content_list_view/in_list_action.dart
@@ -105,7 +105,7 @@ class _InListContentActionState extends State<InListContentAction> with SingleTi
           onTap: widget.onTap,
           child: Container(
             padding: EdgeInsets.symmetric(horizontal: widget.horizontalPadding),
-            height: kSongTileHeight,
+            height: kSongTileHeight(MediaQuery.of(context).textScaleFactor),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.center,
               mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/widgets/content_list_view/song_tile.dart
+++ b/lib/widgets/content_list_view/song_tile.dart
@@ -17,13 +17,12 @@ TextStyle _titleTheme(ThemeData theme) => theme.textTheme.headline6!;
 
 /// Calculate the height of one line of text rendered with the [style] and [textScaleFactor].
 double _lineHeight(TextStyle style, double textScaleFactor) {
-  final TextPainter textPainter = TextPainter(
+  return TextPainter(
     text: TextSpan(text: "", style: style),
     maxLines: 1,
     textDirection: TextDirection.ltr,
     textScaleFactor: textScaleFactor,
-  )..layout(minWidth: 0, maxWidth: double.infinity);
-  return textPainter.size.height;
+  ).preferredLineHeight;
 }
 
 /// The height of the title and subtitle part of the [SongTile] widget for the given [context].

--- a/lib/widgets/content_list_view/song_tile.dart
+++ b/lib/widgets/content_list_view/song_tile.dart
@@ -5,8 +5,30 @@ import 'package:sweyer/sweyer.dart';
 
 /// Needed for scrollbar label computations
 const double _tileVerticalPadding = 8.0;
+
+/// Calculate the height of one line of text rendered with the [style] and [textScaleFactor].
+double _lineHeight(TextStyle style, double textScaleFactor) {
+  final TextPainter textPainter = TextPainter(
+    text: TextSpan(text: "", style: style),
+    maxLines: 1,
+    textDirection: TextDirection.ltr,
+    textScaleFactor: textScaleFactor,
+  )..layout(minWidth: 0, maxWidth: double.infinity);
+  return textPainter.size.height;
+}
+
+/// The height of the title and subtitle part of the [SongTile] widget for the given [context].
+double kSongTileTextHeight(context) {
+  final textScaleFactor = MediaQuery.of(context).textScaleFactor;
+  final theme = Theme.of(context);
+  return _lineHeight(_SongTileState.titleTheme(theme), textScaleFactor) +
+      _lineHeight(ArtistWidget.defaultTextStyle(theme), textScaleFactor) +
+      _SongTileState.subtitleTopPadding +
+      _SongTileState.subtitleBottomPadding;
+}
+
 double kSongTileHeight(BuildContext context) =>
-    (kSongTileArtSize + _tileVerticalPadding * 2) * math.max(0.95, MediaQuery.of(context).textScaleFactor);
+    math.max(kSongTileArtSize, kSongTileTextHeight(context)) + _tileVerticalPadding * 2;
 const double kSongTileHorizontalPadding = 10.0;
 const SongTileClickBehavior kSongTileClickBehavior = SongTileClickBehavior.play;
 const SongTileVariant kSongTileVariant = SongTileVariant.albumArt;
@@ -165,6 +187,12 @@ class SongTile extends SelectableWidget<SelectionEntry> {
 
 class _SongTileState extends SelectableState<SelectionEntry<Song>, SongTile> with ContentTileComponentsMixin {
   Color? previousBackgroundColor;
+  /// The padding that is added to the top of the subtitle widget.
+  static const subtitleTopPadding = 4.0;
+  /// The padding that is added to the bottom of the subtitle widget.
+  static const subtitleBottomPadding = 3.0;
+  /// The [TextStyle] used for the title text from the [theme].
+  static TextStyle titleTheme(ThemeData theme) => theme.textTheme.headline6!;
 
   @override
   void didUpdateWidget(SongTile oldWidget) {
@@ -219,7 +247,7 @@ class _SongTileState extends SelectableState<SelectionEntry<Song>, SongTile> wit
     Widget title = Text(
       widget.song.title,
       overflow: TextOverflow.ellipsis,
-      style: theme.textTheme.headline6,
+      style: titleTheme(theme),
     );
     Widget subtitle = ArtistWidget(
       artist: widget.song.artist,
@@ -277,9 +305,9 @@ class _SongTileState extends SelectableState<SelectionEntry<Song>, SongTile> wit
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
                         title,
-                        const SizedBox(height: 4.0),
+                        const SizedBox(height: subtitleTopPadding),
                         subtitle,
-                        const SizedBox(height: 3.0),
+                        const SizedBox(height: subtitleBottomPadding),
                       ],
                     ),
                   ),

--- a/lib/widgets/content_list_view/song_tile.dart
+++ b/lib/widgets/content_list_view/song_tile.dart
@@ -5,8 +5,8 @@ import 'package:sweyer/sweyer.dart';
 
 /// Needed for scrollbar label computations
 const double _tileVerticalPadding = 8.0;
-double kSongTileHeight(double textScaleFactor) =>
-    (kSongTileArtSize + _tileVerticalPadding * 2) * math.max(0.95, textScaleFactor);
+double kSongTileHeight(BuildContext context) =>
+    (kSongTileArtSize + _tileVerticalPadding * 2) * math.max(0.95, MediaQuery.of(context).textScaleFactor);
 const double kSongTileHorizontalPadding = 10.0;
 const SongTileClickBehavior kSongTileClickBehavior = SongTileClickBehavior.play;
 const SongTileVariant kSongTileVariant = SongTileVariant.albumArt;

--- a/lib/widgets/content_list_view/song_tile.dart
+++ b/lib/widgets/content_list_view/song_tile.dart
@@ -1,9 +1,12 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:sweyer/sweyer.dart';
 
 /// Needed for scrollbar label computations
-const double kSongTileHeight = kSongTileArtSize + _tileVerticalPadding * 2;
 const double _tileVerticalPadding = 8.0;
+double kSongTileHeight(double textScaleFactor) =>
+    (kSongTileArtSize + _tileVerticalPadding * 2) * math.max(0.95, textScaleFactor);
 const double kSongTileHorizontalPadding = 10.0;
 const SongTileClickBehavior kSongTileClickBehavior = SongTileClickBehavior.play;
 const SongTileVariant kSongTileVariant = SongTileVariant.albumArt;

--- a/lib/widgets/content_list_view/song_tile.dart
+++ b/lib/widgets/content_list_view/song_tile.dart
@@ -6,6 +6,15 @@ import 'package:sweyer/sweyer.dart';
 /// Needed for scrollbar label computations
 const double _tileVerticalPadding = 8.0;
 
+/// The padding that is added to the top of the subtitle widget.
+const _subtitleTopPadding = 4.0;
+
+/// The padding that is added to the bottom of the subtitle widget.
+const _subtitleBottomPadding = 3.0;
+
+/// The [TextStyle] used for the title text from the [theme].
+TextStyle _titleTheme(ThemeData theme) => theme.textTheme.headline6!;
+
 /// Calculate the height of one line of text rendered with the [style] and [textScaleFactor].
 double _lineHeight(TextStyle style, double textScaleFactor) {
   final TextPainter textPainter = TextPainter(
@@ -21,10 +30,10 @@ double _lineHeight(TextStyle style, double textScaleFactor) {
 double kSongTileTextHeight(context) {
   final textScaleFactor = MediaQuery.of(context).textScaleFactor;
   final theme = Theme.of(context);
-  return _lineHeight(_SongTileState.titleTheme(theme), textScaleFactor) +
+  return _lineHeight(_titleTheme(theme), textScaleFactor) +
       _lineHeight(ArtistWidget.defaultTextStyle(theme), textScaleFactor) +
-      _SongTileState.subtitleTopPadding +
-      _SongTileState.subtitleBottomPadding;
+      _subtitleTopPadding +
+      _subtitleBottomPadding;
 }
 
 double kSongTileHeight(BuildContext context) =>
@@ -187,12 +196,6 @@ class SongTile extends SelectableWidget<SelectionEntry> {
 
 class _SongTileState extends SelectableState<SelectionEntry<Song>, SongTile> with ContentTileComponentsMixin {
   Color? previousBackgroundColor;
-  /// The padding that is added to the top of the subtitle widget.
-  static const subtitleTopPadding = 4.0;
-  /// The padding that is added to the bottom of the subtitle widget.
-  static const subtitleBottomPadding = 3.0;
-  /// The [TextStyle] used for the title text from the [theme].
-  static TextStyle titleTheme(ThemeData theme) => theme.textTheme.headline6!;
 
   @override
   void didUpdateWidget(SongTile oldWidget) {
@@ -247,7 +250,7 @@ class _SongTileState extends SelectableState<SelectionEntry<Song>, SongTile> wit
     Widget title = Text(
       widget.song.title,
       overflow: TextOverflow.ellipsis,
-      style: titleTheme(theme),
+      style: _titleTheme(theme),
     );
     Widget subtitle = ArtistWidget(
       artist: widget.song.artist,
@@ -305,9 +308,9 @@ class _SongTileState extends SelectableState<SelectionEntry<Song>, SongTile> wit
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
                         title,
-                        const SizedBox(height: subtitleTopPadding),
+                        const SizedBox(height: _subtitleTopPadding),
                         subtitle,
-                        const SizedBox(height: subtitleBottomPadding),
+                        const SizedBox(height: _subtitleBottomPadding),
                       ],
                     ),
                   ),

--- a/lib/widgets/scrollbar.dart
+++ b/lib/widgets/scrollbar.dart
@@ -68,7 +68,10 @@ class AppScrollbar extends StatefulWidget {
           ? null
           : (context) {
               final l10n = getl10n(context);
-              final item = list[(controller.position.pixels / kSongTileHeight - 1).clamp(0.0, list.length - 1).round()];
+              final item = list[
+                  (controller.position.pixels / kSongTileHeight(MediaQuery.of(context).textScaleFactor) - 1)
+                      .clamp(0.0, list.length - 1)
+                      .round()];
               return NFScrollLabel(text: () {
                 // TODO: Remove ContentType cast, see https://github.com/dart-lang/language/issues/2315
                 // ignore: unnecessary_cast

--- a/lib/widgets/scrollbar.dart
+++ b/lib/widgets/scrollbar.dart
@@ -68,10 +68,8 @@ class AppScrollbar extends StatefulWidget {
           ? null
           : (context) {
               final l10n = getl10n(context);
-              final item = list[
-                  (controller.position.pixels / kSongTileHeight(MediaQuery.of(context).textScaleFactor) - 1)
-                      .clamp(0.0, list.length - 1)
-                      .round()];
+              final item =
+                  list[(controller.position.pixels / kSongTileHeight(context) - 1).clamp(0.0, list.length - 1).round()];
               return NFScrollLabel(text: () {
                 // TODO: Remove ContentType cast, see https://github.com/dart-lang/language/issues/2315
                 // ignore: unnecessary_cast

--- a/lib/widgets/selection.dart
+++ b/lib/widgets/selection.dart
@@ -931,7 +931,7 @@ class _SelectionActionsBar extends StatelessWidget {
           child: PlayerInterfaceColorWidget(
             color: () => theme.colorScheme.secondary,
             child: Container(
-              height: kSongTileHeight,
+              height: kSongTileHeight(MediaQuery.of(context).textScaleFactor),
               padding: const EdgeInsets.only(bottom: 6.0),
               child: Material(
                 color: Colors.transparent,
@@ -1710,7 +1710,8 @@ class _AddToPlaylistSelectionAction extends StatelessWidget {
           final playlists = ContentControl.instance.state.playlists;
           final screenSize = MediaQuery.of(context).size;
           return SizedBox(
-            height: kSongTileHeight + playlists.length * kPersistentQueueTileHeight,
+            height:
+                kSongTileHeight(MediaQuery.of(context).textScaleFactor) + playlists.length * kPersistentQueueTileHeight,
             width: screenSize.width,
             child: ScrollConfiguration(
               behavior: const GlowlessScrollBehavior(),

--- a/lib/widgets/selection.dart
+++ b/lib/widgets/selection.dart
@@ -931,7 +931,7 @@ class _SelectionActionsBar extends StatelessWidget {
           child: PlayerInterfaceColorWidget(
             color: () => theme.colorScheme.secondary,
             child: Container(
-              height: kSongTileHeight(MediaQuery.of(context).textScaleFactor),
+              height: kSongTileHeight(context),
               padding: const EdgeInsets.only(bottom: 6.0),
               child: Material(
                 color: Colors.transparent,
@@ -1710,8 +1710,7 @@ class _AddToPlaylistSelectionAction extends StatelessWidget {
           final playlists = ContentControl.instance.state.playlists;
           final screenSize = MediaQuery.of(context).size;
           return SizedBox(
-            height:
-                kSongTileHeight(MediaQuery.of(context).textScaleFactor) + playlists.length * kPersistentQueueTileHeight,
+            height: kSongTileHeight(context) + playlists.length * kPersistentQueueTileHeight,
             width: screenSize.width,
             child: ScrollConfiguration(
               behavior: const GlowlessScrollBehavior(),

--- a/test/routes/home_route_test.dart
+++ b/test/routes/home_route_test.dart
@@ -152,4 +152,34 @@ void main() {
       expect(systemObserver.closeRequests, 1);
     });
   });
+
+  group('app does not overlap the track panel and the tab bar', () {
+    testWidgets('for the normal text scale', (WidgetTester tester) async {
+      await tester.runAppTest(() async {
+        final tabBarTop = tester.getBottomLeft(find.byType(NFTabBar)).dy;
+        final trackPanelTop =
+            tester.getTopLeft(find.descendant(of: find.byType(PlayerRoute), matching: find.byType(TrackPanel))).dy;
+        expect(tabBarTop, trackPanelTop);
+      });
+    });
+    testWidgets('for large text scale', (WidgetTester tester) async {
+      // TODO: Increase the scale factor once the other unrelated overflows are handled.
+      tester.binding.window.platformDispatcher.textScaleFactorTestValue = 1.2; // 2.5;
+      await tester.runAppTest(() async {
+        final tabBarTop = tester.getBottomLeft(find.byType(NFTabBar)).dy;
+        final trackPanelTop =
+            tester.getTopLeft(find.descendant(of: find.byType(PlayerRoute), matching: find.byType(TrackPanel))).dy;
+        expect(tabBarTop, trackPanelTop);
+      });
+    });
+    testWidgets('for small text scale', (WidgetTester tester) async {
+      tester.binding.window.platformDispatcher.textScaleFactorTestValue = 0.5;
+      await tester.runAppTest(() async {
+        final tabBarTop = tester.getBottomLeft(find.byType(NFTabBar)).dy;
+        final trackPanelTop =
+            tester.getTopLeft(find.descendant(of: find.byType(PlayerRoute), matching: find.byType(TrackPanel))).dy;
+        expect(tabBarTop, trackPanelTop);
+      });
+    });
+  });
 }


### PR DESCRIPTION
This fixes the layout issues seen when the system font size is increased. The `math.max` makes sure that the `kSongTileHeight` doesn't get too small. This is not the most elegant solution, since it requires us to pass the `textScaleFactor` around a lot, let me know if you find a better solution. Fixes #66.

| Largest font | Smallest font |
|--------------|----------------|
| ![Largest font](https://user-images.githubusercontent.com/6966049/174413100-aa95cd41-14fd-4e37-b3bc-595635dd2e1c.png) | ![Smallest font](https://user-images.githubusercontent.com/6966049/174413106-e6076b7b-a03f-4a8a-b1e4-f3d735f1e169.png) |
 