### PR TITLE
Emerge buttons from the right

### DIFF
--- a/lib/widgets/selection.dart
+++ b/lib/widgets/selection.dart
@@ -920,13 +920,13 @@ class _SelectionActionsBar extends StatelessWidget {
   }
 }
 
-/// Animation that emerges the item, by default from left to right.
+/// Animation that emerges the item, by default from right to left.
 class EmergeAnimation extends AnimatedWidget {
   const EmergeAnimation({
     Key? key,
     required Animation<double> animation,
     required this.child,
-    this.begin = const Offset(-1.0, 0.0),
+    this.begin = const Offset(1.0, 0.0),
     this.end = Offset.zero,
   }) : super(key: key, listenable: animation);
 


### PR DESCRIPTION
This changes the emerge animation of some buttons to emerge from the right. This looks better in my opinion, because it aligns with the movement of adjacent buttons:

| Current | After |
|----------|------|
| ![Search Selection and Delete Button Behaviour](https://user-images.githubusercontent.com/6966049/169668215-30f68cc1-3f02-4c33-b700-3c4a950a60a9.gif) | ![New select All button animation](https://user-images.githubusercontent.com/6966049/174872511-f2ebe791-b48d-4e77-b8ac-26e4390e7fd0.gif) |
| ![Emerge animations - Before](https://user-images.githubusercontent.com/6966049/174877519-1769e9a6-33cd-44de-a471-943e51930e10.gif) | ![Emerge animations - After](https://user-images.githubusercontent.com/6966049/174877543-64e6bc1a-5b86-49ba-85e0-193d7f341b4b.gif) |

Sorry, it's a bit hard to see, this was recorded on an emulator.
 