### PR TITLE
Request the READ_MEDIA_AUDIO permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 [@Abestanis]: https://github.com/Abestanis
 
+## 1.0.9
+
+- [Fix being unable to request permissions to view audio files on Android 13 or newer](https://github.com/nt4f04uNd/sweyer/pull/84) **([@Abestanis])**
+
 ## 1.0.8
 
 All the work related to this version can be found in this [project](https://github.com/users/nt4f04uNd/projects/4/views/1)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     package="com.nt4f04und.sweyer">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <!-- Needed to stay awake feature in MediaPlayer -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/lib/logic/device_info.dart
+++ b/lib/logic/device_info.dart
@@ -15,6 +15,11 @@ class DeviceInfoControl extends Control {
   /// starting from API 29.
   bool get useScopedStorageForFileModifications => sdkInt >= 30;
 
+  /// Whether to use the more granular audio permission (READ_MEDIA_AUDIO).
+  ///
+  /// This must be used instead of the storage permission on API level 33 and onward.
+  bool get useAudioPermission => sdkInt >= 33;
+
   @override
   Future<void> init() async {
     super.init();

--- a/lib/logic/permissions.dart
+++ b/lib/logic/permissions.dart
@@ -5,30 +5,29 @@ import 'package:permission_handler/permission_handler.dart';
 class Permissions {
   static Permissions instance = Permissions();
 
-  /// Whether storage permission is granted
-  late PermissionStatus _permissionStorageStatus;
+  /// Whether audio access permission is granted
   late PermissionStatus _permissionAudioStatus;
 
   /// Returns true if permissions were granted
-  bool get granted => _permissionStorageStatus == PermissionStatus.granted
-      || _permissionAudioStatus == PermissionStatus.granted;
+  bool get granted => _permissionAudioStatus == PermissionStatus.granted;
 
   /// Returns true if permissions were not granted
   bool get notGranted => !granted;
 
+  /// The permission to use when requesting access to the audio files on the device
+  Permission get _audioPermission =>
+      DeviceInfoControl.instance.useAudioPermission ? Permission.audio : Permission.storage;
+
   Future<void> init() async {
-    _permissionStorageStatus = await Permission.storage.status;
-    _permissionAudioStatus = await Permission.audio.status;
+    _permissionAudioStatus = await _audioPermission.status;
   }
 
   Future<void> requestClick() async {
     final responses = await [Permission.storage, Permission.audio].request();
-    _permissionStorageStatus = responses[Permission.storage] ?? PermissionStatus.denied;
-    _permissionAudioStatus = responses[Permission.audio] ?? PermissionStatus.denied;
+    _permissionAudioStatus = responses[_audioPermission] ?? PermissionStatus.denied;
     if (granted) {
       await ContentControl.instance.init();
-    } else if (_permissionStorageStatus == PermissionStatus.permanentlyDenied ||
-        _permissionAudioStatus == PermissionStatus.permanentlyDenied) {
+    } else if (_permissionAudioStatus == PermissionStatus.permanentlyDenied) {
       final l10n = staticl10n;
       await ShowFunctions.instance.showToast(
         msg: l10n.allowAccessToExternalStorageManually,

--- a/lib/logic/permissions.dart
+++ b/lib/logic/permissions.dart
@@ -7,22 +7,28 @@ class Permissions {
 
   /// Whether storage permission is granted
   late PermissionStatus _permissionStorageStatus;
+  late PermissionStatus _permissionAudioStatus;
 
   /// Returns true if permissions were granted
-  bool get granted => _permissionStorageStatus == PermissionStatus.granted;
+  bool get granted => _permissionStorageStatus == PermissionStatus.granted
+      || _permissionAudioStatus == PermissionStatus.granted;
 
   /// Returns true if permissions were not granted
   bool get notGranted => !granted;
 
   Future<void> init() async {
     _permissionStorageStatus = await Permission.storage.status;
+    _permissionAudioStatus = await Permission.audio.status;
   }
 
   Future<void> requestClick() async {
-    _permissionStorageStatus = await Permission.storage.request();
-    if (_permissionStorageStatus == PermissionStatus.granted) {
+    final responses = await [Permission.storage, Permission.audio].request();
+    _permissionStorageStatus = responses[Permission.storage] ?? PermissionStatus.denied;
+    _permissionAudioStatus = responses[Permission.audio] ?? PermissionStatus.denied;
+    if (granted) {
       await ContentControl.instance.init();
-    } else if (_permissionStorageStatus == PermissionStatus.permanentlyDenied) {
+    } else if (_permissionStorageStatus == PermissionStatus.permanentlyDenied ||
+        _permissionAudioStatus == PermissionStatus.permanentlyDenied) {
       final l10n = staticl10n;
       await ShowFunctions.instance.showToast(
         msg: l10n.allowAccessToExternalStorageManually,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/nt4f04uNd/sweyer
 repository: https://github.com/nt4f04uNd/sweyer
 issue_tracker: https://github.com/nt4f04uNd/sweyer/issues
 publish_to: none
-version: 1.0.8+10
+version: 1.0.9+11
 
 environment:
   sdk: '>=2.17.0 <3.0.0'

--- a/test/golden/routes_golden_test.dart
+++ b/test/golden/routes_golden_test.dart
@@ -112,13 +112,11 @@ void main() {
 
     testAppGoldens('selection_deletion_dialog_songs_tab', (WidgetTester tester) async {
       final List<Song> songs = List.unmodifiable(List.generate(10, (index) => songWith(id: index)));
-      await tester.runAsync(() async {
-        await setUpAppTest(() {
-          final fake = FakeDeviceInfoControl();
-          DeviceInfoControl.instance = fake;
-          fake.sdkInt = 29;
-          FakeContentChannel.instance.songs = songs.toList();
-        });
+      await setUpAppTest(() {
+        final fake = FakeDeviceInfoControl();
+        DeviceInfoControl.instance = fake;
+        fake.sdkInt = 29;
+        FakeContentChannel.instance.songs = songs.toList();
       });
       await tester.runAppTest(() async {
         await tester.pumpAndSettle();
@@ -133,17 +131,15 @@ void main() {
 
   group('persistent_queue_route', () {
     testAppGoldens('album_route', (WidgetTester tester) async {
-      await tester.runAsync(() async {
-        await setUpAppTest(() {
-          FakeContentChannel.instance.songs = [
-            songWith(id: 0, track: null, title: 'Null Song 1'),
-            songWith(id: 5, track: null, title: 'Null Song 2'),
-            songWith(id: 3, track: '1', title: 'First Song'),
-            songWith(id: 2, track: '2', title: 'Second Song'),
-            songWith(id: 4, track: '3', title: 'Third Song'),
-            songWith(id: 1, track: '4', title: 'Fourth Song'),
-          ];
-        });
+      await setUpAppTest(() {
+        FakeContentChannel.instance.songs = [
+          songWith(id: 0, track: null, title: 'Null Song 1'),
+          songWith(id: 5, track: null, title: 'Null Song 2'),
+          songWith(id: 3, track: '1', title: 'First Song'),
+          songWith(id: 2, track: '2', title: 'Second Song'),
+          songWith(id: 4, track: '3', title: 'Third Song'),
+          songWith(id: 1, track: '4', title: 'Fourth Song'),
+        ];
       });
       await tester.runAppTest(() async {
         HomeRouter.instance.goto(HomeRoutes.factory.content(albumWith()));
@@ -306,15 +302,13 @@ void main() {
       final localFavoriteButNotInMediaStoreSong = songWith(id: 2, title: 'Local only favorite');
       final mediaStoreFavoriteButNotLocalSong =
           songWith(id: 3, isFavoriteInMediaStore: true, title: 'MediaStore only favorite');
-      await tester.runAsync(() async {
-        await setUpAppTest(() async {
-          FakeContentChannel.instance.songs = [
-            songWith(),
-            localFavoriteAndMediaStoreSong,
-            localFavoriteButNotInMediaStoreSong,
-            mediaStoreFavoriteButNotLocalSong,
-          ];
-        });
+      await setUpAppTest(() {
+        FakeContentChannel.instance.songs = [
+          songWith(),
+          localFavoriteAndMediaStoreSong,
+          localFavoriteButNotInMediaStoreSong,
+          mediaStoreFavoriteButNotLocalSong,
+        ];
       });
       await tester.runAppTest(
         () async {

--- a/test/golden/routes_golden_test.dart
+++ b/test/golden/routes_golden_test.dart
@@ -15,6 +15,7 @@ void main() {
       await setUpAppTest(() {
         permissionsObserver = PermissionsChannelObserver(tester.binding);
         permissionsObserver.setPermission(Permission.storage, PermissionStatus.denied);
+        permissionsObserver.setPermission(Permission.audio, PermissionStatus.denied);
       });
       await tester.runAppTest(() async {
         await tester.tap(find.text(l10n.grant));

--- a/test/logic/player/favorites_test.dart
+++ b/test/logic/player/favorites_test.dart
@@ -11,7 +11,7 @@ void main() {
   final favoriteSong3 = songWith(id: 5, title: 'Song 5', isFavoriteInMediaStore: true);
 
   setUp(() async {
-    await setUpAppTest(() async {
+    await setUpAppTest(() {
       FakeContentChannel.instance.songs = [
         notFavoriteSong1,
         notFavoriteSong2,

--- a/test/observer/permissions.dart
+++ b/test/observer/permissions.dart
@@ -39,6 +39,9 @@ class PermissionsChannelObserver {
           for (final int permissionValue in List<int>.from(call.arguments)) {
             final permission = Permission.byValue(permissionValue);
             _requestedPermissions.add(permission);
+          }
+          for (final int permissionValue in List<int>.from(call.arguments)) {
+            final permission = Permission.byValue(permissionValue);
             final permissionStatus = await getStatus(permission);
             permissionStatuses[permissionValue] = permissionStatus.index;
           }

--- a/test/routes/home_route_test.dart
+++ b/test/routes/home_route_test.dart
@@ -43,7 +43,7 @@ void main() {
     // On Android 13+ the storage permission is removed and reports as permanentlyDenied.
     // If the user granted audio permissions, we have access to the music
     // and don't want to show the permission request screen.
-    testWidgets('does not show when one removed permission is permanently denied', (WidgetTester tester) async {
+    testWidgets('does not show when removed storage permission is permanently denied', (WidgetTester tester) async {
       late PermissionsChannelObserver permissionsObserver;
       await setUpAppTest(() {
         permissionsObserver = PermissionsChannelObserver(tester.binding);
@@ -53,6 +53,22 @@ void main() {
       await tester.runAppTest(() async {
         expect(Permissions.instance.granted, true);
         expect(find.byType(Home), findsOneWidget, reason: 'Audio permissions was already granted');
+      });
+    });
+
+    // The audio permission is new in Android 13 and reports as permanentlyDenied on earlier versions.
+    // If the user granted storage permissions, we have access to the music
+    // and don't want to show the permission request screen.
+    testWidgets('does not show when non-existent audio permission is permanently denied', (WidgetTester tester) async {
+      late PermissionsChannelObserver permissionsObserver;
+      await setUpAppTest(() {
+        permissionsObserver = PermissionsChannelObserver(tester.binding);
+        permissionsObserver.setPermission(Permission.storage, PermissionStatus.granted);
+        permissionsObserver.setPermission(Permission.audio, PermissionStatus.permanentlyDenied);
+      });
+      await tester.runAppTest(() async {
+        expect(Permissions.instance.granted, true);
+        expect(find.byType(Home), findsOneWidget, reason: 'Storage permissions was already granted');
       });
     });
 

--- a/test/routes/home_route_test.dart
+++ b/test/routes/home_route_test.dart
@@ -69,6 +69,7 @@ void main() {
         permissionsObserver.isOpeningSettingsSuccessful = false;
         final ToastChannelObserver toastObserver = ToastChannelObserver(tester);
         await tester.tap(find.text(l10n.grant));
+        await tester.pumpAndSettle();
         expect(permissionsObserver.openSettingsRequests, 1);
         expect(toastObserver.toastMessagesLog, [l10n.allowAccessToExternalStorageManually, l10n.openAppSettingsError]);
 

--- a/test/routes/player_route_test.dart
+++ b/test/routes/player_route_test.dart
@@ -131,10 +131,8 @@ void main() {
       songWith(id: 1),
       songWith(id: 2),
     ]);
-    await tester.runAsync(() async {
-      await setUpAppTest(() {
-        FakeContentChannel.instance.songs = songs.toList();
-      });
+    await setUpAppTest(() {
+      FakeContentChannel.instance.songs = songs.toList();
     });
     PlaybackControl.instance.changeSong(songs[1]);
     await tester.runAppTest(() async {
@@ -157,10 +155,8 @@ void main() {
       songWith(id: 1),
       songWith(id: 2),
     ]);
-    await tester.runAsync(() async {
-      await setUpAppTest(() {
-        FakeContentChannel.instance.songs = songs.toList();
-      });
+    await setUpAppTest(() {
+      FakeContentChannel.instance.songs = songs.toList();
     });
     PlaybackControl.instance.changeSong(songs[1]);
     await tester.runAppTest(() async {

--- a/test/routes/tabs_route_test.dart
+++ b/test/routes/tabs_route_test.dart
@@ -77,10 +77,8 @@ void main() {
       songWith(id: 1, dateModified: 1),
       songWith(id: 2, dateModified: 0),
     ]);
-    await tester.runAsync(() async {
-      await setUpAppTest(() {
-        FakeContentChannel.instance.songs = songs.toList();
-      });
+    await setUpAppTest(() {
+      FakeContentChannel.instance.songs = songs.toList();
     });
     await tester.runAppTest(() async {
       tester.expectSongTiles(songs);
@@ -98,10 +96,8 @@ void main() {
       songWith(id: 1, dateModified: 1, title: 'b'),
       songWith(id: 2, dateModified: 0, title: 'a'),
     ]);
-    await tester.runAsync(() async {
-      await setUpAppTest(() {
-        FakeContentChannel.instance.songs = songs.toList();
-      });
+    await setUpAppTest(() {
+      FakeContentChannel.instance.songs = songs.toList();
     });
     await tester.runAppTest(() async {
       tester.expectSongTiles(songs);
@@ -121,10 +117,8 @@ void main() {
       songWith(id: 1),
       songWith(id: 2),
     ]);
-    await tester.runAsync(() async {
-      await setUpAppTest(() {
-        FakeContentChannel.instance.songs = songs.toList();
-      });
+    await setUpAppTest(() {
+      FakeContentChannel.instance.songs = songs.toList();
     });
     await tester.runAppTest(() async {
       tester.expectSongTiles(songs);

--- a/test/test.dart
+++ b/test/test.dart
@@ -119,7 +119,7 @@ Future<void> setUpAppTest([VoidCallback? configureFakes]) async {
   ContentChannel.instance = FakeContentChannel(binding);
   QueueControl.instance = FakeQueueControl();
   ThemeControl.instance = FakeThemeControl();
-  JustAudioPlatform.instance = MockJustAudio();
+  JustAudioPlatform.instance = MockJustAudio(binding);
   PackageInfoPlatform.instance = MethodChannelPackageInfo();
   PlayerInterfaceColorStyleControl.instance = PlayerInterfaceColorStyleControl();
   binding.defaultBinaryMessenger.setMockMethodCallHandler(const MethodChannel('dev.fluttercommunity.plus/package_info'),
@@ -189,7 +189,11 @@ Future<void> setUpAppTest([VoidCallback? configureFakes]) async {
   ThemeControl.instance.init();
   ThemeControl.instance.initSystemUi();
   await Permissions.instance.init();
-  await ContentControl.instance.init();
+  if (binding.inTest) {
+    await binding.runAsync(() => ContentControl.instance.init());
+  } else {
+    await ContentControl.instance.init();
+  }
 
   // Called in the [App] widget
   NFWidgets.init(


### PR DESCRIPTION
On Android 13, `READ_EXTERNAL_STORAGE` has been split into more [granular permissions](https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions), like `READ_MEDIA_AUDIO`. We need to request this permission to be able to query music from the content provider service. Fixes #83.

The `READ_MEDIA_AUDIO` will automatically be granted when requested if `READ_EXTERNAL_STORAGE` was previously granted.