### PR TITLE
Fix settings button visible on insertion settings page

### DIFF
--- a/lib/routes/home_route/persistent_queue_route.dart
+++ b/lib/routes/home_route/persistent_queue_route.dart
@@ -242,12 +242,9 @@ class _PersistentQueueRouteState extends State<PersistentQueueRoute> with Select
       onSubmit: (entries) {
         int index;
         if (selectedSong == null) {
-          index = 1;
+          index = 0;
         } else {
-          index = songs.indexOf(selectedSong!) + 2;
-          if (index <= 0) {
-            index = 1;
-          }
+          index = songs.indexOf(selectedSong!) + 1;
         }
         ContentControl.instance.insertSongsInPlaylist(
           index: index,

--- a/lib/routes/home_route/player_route.dart
+++ b/lib/routes/home_route/player_route.dart
@@ -1102,7 +1102,7 @@ class _SaveQueueAsPlaylistActionState extends State<_SaveQueueAsPlaylistAction> 
       bool success = false;
       try {
         await ContentControl.instance.insertSongsInPlaylist(
-          index: 1,
+          index: 0,
           songs: songs,
           playlist: playlist,
         );

--- a/lib/routes/selection_route.dart
+++ b/lib/routes/selection_route.dart
@@ -17,7 +17,6 @@ class _SelectionRouteState extends State<SelectionRoute> {
   late final HomeRouter nestedHomeRouter = HomeRouter.selection(widget.selectionArguments);
   late final ContentSelectionController controller;
   late ChildBackButtonDispatcher _backButtonDispatcher;
-  bool settingsOpened = false;
 
   @override
   void didChangeDependencies() {
@@ -29,6 +28,7 @@ class _SelectionRouteState extends State<SelectionRoute> {
   @override
   void initState() {
     super.initState();
+    var settingsOpened = false;
     controller = ContentSelectionController.createAlwaysInSelection(
       context: context,
       actionsBuilder: (context) {
@@ -36,31 +36,33 @@ class _SelectionRouteState extends State<SelectionRoute> {
         final settingsPageBuilder = widget.selectionArguments.settingsPageBuilder;
         return [
           if (settingsPageBuilder != null)
-            AnimatedSwitcher(
-              duration: const Duration(milliseconds: 240),
-              switchInCurve: Curves.easeOutCubic,
-              switchOutCurve: Curves.easeInCubic,
-              child: settingsOpened
-                  ? const SizedBox.shrink()
-                  : NFIconButton(
-                      icon: const Icon(Icons.settings_rounded),
-                      onPressed: () async {
-                        if (!settingsOpened) {
-                          setState(() {
-                            settingsOpened = true;
-                          });
-                          await nestedHomeRouter.navigatorKey.currentState!.push(StackFadeRouteTransition(
-                            child: Builder(builder: (context) => settingsPageBuilder(context)),
-                            transitionSettings: AppRouter.instance.transitionSettings.greyDismissible,
-                          ));
-                          if (mounted) {
+            StatefulBuilder(
+              builder: (context, setState) => AnimatedSwitcher(
+                duration: const Duration(milliseconds: 240),
+                switchInCurve: Curves.easeOutCubic,
+                switchOutCurve: Curves.easeInCubic,
+                child: settingsOpened
+                    ? const SizedBox.shrink()
+                    : NFIconButton(
+                        icon: const Icon(Icons.settings_rounded),
+                        onPressed: () async {
+                          if (!settingsOpened) {
                             setState(() {
-                              settingsOpened = false;
+                              settingsOpened = true;
                             });
+                            await nestedHomeRouter.navigatorKey.currentState!.push(StackFadeRouteTransition(
+                              child: Builder(builder: (context) => settingsPageBuilder(context)),
+                              transitionSettings: AppRouter.instance.transitionSettings.greyDismissible,
+                            ));
+                            if (mounted) {
+                              setState(() {
+                                settingsOpened = false;
+                              });
+                            }
                           }
-                        }
-                      },
-                    ),
+                        },
+                      ),
+              ),
             ),
           const SizedBox(width: 6.0),
           AnimatedBuilder(

--- a/lib/widgets/selection.dart
+++ b/lib/widgets/selection.dart
@@ -1741,7 +1741,7 @@ class _AddToPlaylistSelectionAction extends StatelessWidget {
                 onItemTap: (index) {
                   final playlist = playlists[index];
                   ContentControl.instance.insertSongsInPlaylist(
-                    index: playlist.length + 1,
+                    index: playlist.length,
                     songs: ContentUtils.flatten(ContentUtils.selectionPackAndSort(controller.data).merged),
                     playlist: playlist,
                   );

--- a/sweyer_plugin/android/src/main/java/com/nt4f04und/sweyer/sweyer_plugin/SweyerPlugin.java
+++ b/sweyer_plugin/android/src/main/java/com/nt4f04und/sweyer/sweyer_plugin/SweyerPlugin.java
@@ -413,7 +413,8 @@ public class SweyerPlugin implements FlutterPlugin, MethodCallHandler, ActivityA
                                 );
                                 values.put(
                                         MediaStore.Audio.Playlists.Members.PLAY_ORDER,
-                                        i + index
+                                        // Play order is one based, so add 1 to the zero based index.
+                                        i + index + 1
                                 );
                                 valuesList.add(values);
                             }

--- a/sweyer_plugin/lib/sweyer_plugin.dart
+++ b/sweyer_plugin/lib/sweyer_plugin.dart
@@ -130,7 +130,7 @@ class SweyerPlugin {
     required PlatformPlaylist playlist,
   }) {
     assert(songs.isNotEmpty);
-    assert(index >= 0 && index <= playlist.songIds.length + 1);
+    assert(index >= 0 && index <= playlist.songIds.length);
     return SweyerPluginPlatform.instance.insertSongsInPlaylist(
       index: index,
       songIds: songs.map((song) => song.sourceId).toList(),

--- a/test/fakes/fake_sweyer_plugin_platform.dart
+++ b/test/fakes/fake_sweyer_plugin_platform.dart
@@ -61,7 +61,7 @@ class FakeSweyerPluginPlatform extends SweyerPluginPlatform {
     required int playlistId,
   }) async {
     final playlist = playlists!.firstWhere((playlist) => playlist.id == playlistId);
-    playlist.songIds.insertAll(index - 1, songIds);
+    playlist.songIds.insertAll(index, songIds);
   }
 
   @override

--- a/test/fakes/fake_sweyer_plugin_platform.dart
+++ b/test/fakes/fake_sweyer_plugin_platform.dart
@@ -59,7 +59,10 @@ class FakeSweyerPluginPlatform extends SweyerPluginPlatform {
     required int index,
     required List<int> songIds,
     required int playlistId,
-  }) async {}
+  }) async {
+    final playlist = playlists!.firstWhere((playlist) => playlist.id == playlistId);
+    playlist.songIds.insertAll(index - 1, songIds);
+  }
 
   @override
   Future<bool> isIntentActionView() async {

--- a/test/routes/selection_route_test.dart
+++ b/test/routes/selection_route_test.dart
@@ -1,0 +1,265 @@
+import 'package:flutter/material.dart';
+
+import '../test.dart';
+
+void main() {
+  setUp(() async {
+    await setUpAppTest();
+  });
+
+  group('playlist add element selection screen', () {
+    testWidgets('hides config button on insertion order config screen', (WidgetTester tester) async {
+      await tester.runAppTest(() async {
+        HomeRouter.instance.goto(HomeRoutes.factory.content(playlistWith()));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.add_rounded).first);
+        await tester.runAsync(() async {
+          // The marquee widget starts a future, we must use runAsync
+          await tester.pumpAndSettle();
+          expect(find.byIcon(Icons.settings_rounded).hitTestable(), findsOneWidget);
+
+          // Open insertion settings
+          await tester.tap(find.descendant(
+            of: find.byType(SelectionActionsBar),
+            matching: find.byIcon(Icons.settings_rounded).hitTestable(),
+          ));
+          await tester.pumpAndSettle();
+          expect(find.byIcon(Icons.settings_rounded).hitTestable(), findsNothing);
+
+          // Close insertion settings
+          await tester.tap(find.byIcon(Icons.arrow_back_rounded).hitTestable());
+          await tester.pumpAndSettle();
+          expect(find.byIcon(Icons.settings_rounded).hitTestable(), findsOneWidget);
+        });
+      });
+    });
+
+    testWidgets('allows to finish insertion from insertion order config screen', (WidgetTester tester) async {
+      final song0 = songWith(id: 0, title: 'Song 0');
+      final song1 = songWith(id: 1, title: 'Song 1');
+      final playlist = playlistWith(songIds: [song0.id]);
+      await setUpAppTest(() {
+        FakeSweyerPluginPlatform.instance.songs = [song0, song1];
+        FakeSweyerPluginPlatform.instance.playlists = [playlist];
+      });
+      await tester.runAppTest(() async {
+        HomeRouter.instance.goto(HomeRoutes.factory.content(playlist));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.add_rounded).first);
+        await tester.runAsync(() async {
+          // The marquee widget starts a future, we must use runAsync
+          await tester.pumpAndSettle();
+          expect(tester.widget<ElevatedButton>(find.widgetWithText(ElevatedButton, l10n.done)).enabled, isFalse);
+
+          // Open insertion settings
+          await tester.tap(find.descendant(
+            of: find.byType(SelectionActionsBar),
+            matching: find.byIcon(Icons.settings_rounded).hitTestable(),
+          ));
+          await tester.pumpAndSettle();
+          expect(tester.widget<ElevatedButton>(find.widgetWithText(ElevatedButton, l10n.done)).enabled, isFalse);
+
+          // Close insertion settings
+          await tester.tap(find.byIcon(Icons.arrow_back_rounded).hitTestable());
+          await tester.pumpAndSettle();
+
+          // Select Song 1
+          await tester.tap(find.descendant(
+              of: find.ancestor(of: find.text(song1.title), matching: find.byType(SongTile)),
+              matching: find.byIcon(Icons.add_rounded)));
+          await tester.pumpAndSettle();
+          expect(tester.widget<ElevatedButton>(find.widgetWithText(ElevatedButton, l10n.done)).enabled, isTrue);
+
+          // Open insertion settings
+          await tester.tap(find.descendant(
+            of: find.byType(SelectionActionsBar),
+            matching: find.byIcon(Icons.settings_rounded).hitTestable(),
+          ));
+          await tester.pumpAndSettle();
+          expect(tester.widget<ElevatedButton>(find.widgetWithText(ElevatedButton, l10n.done)).enabled, isTrue);
+
+          // Finish insertion
+          await tester.tap(find.ancestor(of: find.text(l10n.done), matching: find.byType(ElevatedButton)));
+          await tester.pumpAndSettle();
+          expect(find.widgetWithText(SongTile, song1.title).hitTestable(), findsOneWidget);
+          expect(playlist.songs, orderedEquals([song0, song1]));
+        });
+      });
+    });
+
+    testWidgets('counts selection', (WidgetTester tester) async {
+      final song0 = songWith(id: 0, title: 'Song 0');
+      final song1 = songWith(id: 1, title: 'Song 1');
+      final song2 = songWith(id: 2, title: 'Song 2');
+      final playlist = playlistWith(songIds: [song0.id]);
+      await setUpAppTest(() {
+        FakeSweyerPluginPlatform.instance.songs = [song0, song1, song2];
+        FakeSweyerPluginPlatform.instance.playlists = [playlist];
+      });
+      await tester.runAppTest(() async {
+        HomeRouter.instance.goto(HomeRoutes.factory.content(playlist));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.add_rounded).first);
+        await tester.runAsync(() async {
+          // The marquee widget starts a future, we must use runAsync
+          await tester.pumpAndSettle();
+          expect(find.descendant(of: find.byType(SelectionCounter), matching: find.text('0')), findsOneWidget);
+          expect(find.byIcon(Icons.settings_rounded).hitTestable(), findsOneWidget);
+
+          // Select Song 1
+          await tester.tap(find.descendant(
+              of: find.ancestor(of: find.text(song1.title), matching: find.byType(SongTile)),
+              matching: find.byIcon(Icons.add_rounded)));
+          await tester.pumpAndSettle();
+          expect(find.descendant(of: find.byType(SelectionCounter), matching: find.text('1')).hitTestable(),
+              findsOneWidget);
+          expect(tester.widget<ElevatedButton>(find.widgetWithText(ElevatedButton, l10n.done)).enabled, isTrue);
+
+          // Select Song 2
+          await tester.tap(find.descendant(
+              of: find.ancestor(of: find.text(song2.title), matching: find.byType(SongTile)),
+              matching: find.byIcon(Icons.add_rounded)));
+          await tester.pumpAndSettle();
+          expect(find.descendant(of: find.byType(SelectionCounter), matching: find.text('2')).hitTestable(),
+              findsOneWidget);
+          expect(tester.widget<ElevatedButton>(find.widgetWithText(ElevatedButton, l10n.done)).enabled, isTrue);
+        });
+      });
+    });
+
+    testWidgets('inserts at the end per default', (WidgetTester tester) async {
+      final song0 = songWith(id: 0, title: 'Song 0');
+      final song1 = songWith(id: 1, title: 'Song 1');
+      final song2 = songWith(id: 2, title: 'Song 2');
+      final playlist = playlistWith(songIds: [song0.id, song1.id]);
+      await setUpAppTest(() {
+        FakeSweyerPluginPlatform.instance.songs = [song0, song1, song2];
+        FakeSweyerPluginPlatform.instance.playlists = [playlist];
+      });
+      await tester.runAppTest(() async {
+        HomeRouter.instance.goto(HomeRoutes.factory.content(playlist));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.add_rounded).first);
+        await tester.runAsync(() async {
+          // The marquee widget starts a future, we must use runAsync
+          await tester.pumpAndSettle();
+          expect(find.byIcon(Icons.settings_rounded).hitTestable(), findsOneWidget);
+
+          // Select Song 2
+          await tester.tap(find.descendant(
+              of: find.ancestor(of: find.text(song2.title), matching: find.byType(SongTile)),
+              matching: find.byIcon(Icons.add_rounded)));
+          await tester.pumpAndSettle();
+
+          // Add selected Song 2 to playlist
+          await tester.tap(find.ancestor(of: find.text(l10n.done), matching: find.byType(ElevatedButton)));
+          await tester.pumpAndSettle();
+          expect(find.widgetWithText(SongTile, song2.title).hitTestable(), findsOneWidget);
+          expect(playlist.songs, orderedEquals([song0, song1, song2]));
+        });
+      });
+    });
+
+    testWidgets('allows insertion at the beginning', (WidgetTester tester) async {
+      final song0 = songWith(id: 0, title: 'Song 0');
+      final song1 = songWith(id: 1, title: 'Song 1');
+      final song2 = songWith(id: 2, title: 'Song 2');
+      final playlist = playlistWith(songIds: [song0.id, song1.id]);
+      await setUpAppTest(() {
+        FakeSweyerPluginPlatform.instance.songs = [song0, song1, song2];
+        FakeSweyerPluginPlatform.instance.playlists = [playlist];
+      });
+      await tester.runAppTest(() async {
+        HomeRouter.instance.goto(HomeRoutes.factory.content(playlist));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.add_rounded).first);
+        await tester.runAsync(() async {
+          // The marquee widget starts a future, we must use runAsync
+          await tester.pumpAndSettle();
+          expect(find.byIcon(Icons.settings_rounded).hitTestable(), findsOneWidget);
+
+          // Select Song 2
+          await tester.tap(find.descendant(
+              of: find.ancestor(of: find.text(song2.title), matching: find.byType(SongTile)),
+              matching: find.byIcon(Icons.add_rounded)));
+          await tester.pumpAndSettle();
+
+          // Open insertion settings
+          await tester.tap(find.descendant(
+            of: find.byType(SelectionActionsBar),
+            matching: find.byIcon(Icons.settings_rounded).hitTestable(),
+          ));
+          await tester.pumpAndSettle();
+          expect(
+              tester
+                  .widget<InListContentAction>(find.widgetWithText(InListContentAction, l10n.insertAtTheBeginning))
+                  .color,
+              isNot(FakeThemeControl.instance.theme.colorScheme.primary));
+
+          // Select insert at beginning
+          await tester.tap(find.widgetWithText(InListContentAction, l10n.insertAtTheBeginning));
+          await tester.pumpAndSettle();
+          expect(
+              tester
+                  .widget<InListContentAction>(find.widgetWithText(InListContentAction, l10n.insertAtTheBeginning))
+                  .color,
+              FakeThemeControl.instance.theme.colorScheme.primary);
+
+          // Add selected Song 2 to playlist
+          await tester.tap(find.ancestor(of: find.text(l10n.done), matching: find.byType(ElevatedButton)));
+          await tester.pumpAndSettle();
+          expect(find.widgetWithText(SongTile, song2.title).hitTestable(), findsOneWidget);
+          expect(playlist.songs, orderedEquals([song2, song0, song1]));
+        });
+      });
+    });
+
+    testWidgets('allows insertion at any index', (WidgetTester tester) async {
+      final song0 = songWith(id: 0, title: 'Song 0');
+      final song1 = songWith(id: 1, title: 'Song 1');
+      final song2 = songWith(id: 2, title: 'Song 2');
+      final playlist = playlistWith(songIds: [song0.id, song1.id]);
+      await setUpAppTest(() {
+        FakeSweyerPluginPlatform.instance.songs = [song0, song1, song2];
+        FakeSweyerPluginPlatform.instance.playlists = [playlist];
+      });
+      await tester.runAppTest(() async {
+        HomeRouter.instance.goto(HomeRoutes.factory.content(playlist));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.add_rounded).first);
+        await tester.runAsync(() async {
+          // The marquee widget starts a future, we must use runAsync
+          await tester.pumpAndSettle();
+          expect(find.byIcon(Icons.settings_rounded).hitTestable(), findsOneWidget);
+
+          // Select Song 2
+          await tester.tap(find.descendant(
+              of: find.ancestor(of: find.text(song2.title), matching: find.byType(SongTile)),
+              matching: find.byIcon(Icons.add_rounded)));
+          await tester.pumpAndSettle();
+
+          // Open insertion settings
+          await tester.tap(find.descendant(
+            of: find.byType(SelectionActionsBar),
+            matching: find.byIcon(Icons.settings_rounded).hitTestable(),
+          ));
+          await tester.pumpAndSettle();
+          expect(tester.widget<SongTile>(find.widgetWithText(SongTile, song0.title).hitTestable()).backgroundColor,
+              isNot(FakeThemeControl.instance.theme.colorScheme.primary));
+
+          // Select Song 0
+          await tester.tap(find.widgetWithText(SongTile, song0.title).hitTestable());
+          await tester.pumpAndSettle();
+          expect(tester.widget<SongTile>(find.widgetWithText(SongTile, song0.title).hitTestable()).backgroundColor,
+              FakeThemeControl.instance.theme.colorScheme.primary);
+
+          // Add selected Song 2 to playlist
+          await tester.tap(find.ancestor(of: find.text(l10n.done), matching: find.byType(ElevatedButton)));
+          await tester.pumpAndSettle();
+          expect(find.widgetWithText(SongTile, song2.title).hitTestable(), findsOneWidget);
+          expect(playlist.songs, orderedEquals([song0, song2, song1]));
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
This was originally fixed by #50, but seems to have regressed since then, probably due to a flutter update.

Looks like the dependency on `settingsOpened` was no longer registered in the `initState` function. We work around that by using a `StatefulBuilder`.

It is a bit weird that the goldens on CI did not pick this up in #85, they were showing the button consistently locally.
To make sure this doesn't regress in the future, I also added some tests for the selection route.

*This depends on and includes changes from #89 and will be kept as a draft until it is merged.*