### PR TITLE
Improve startup robustness

### DIFF
--- a/lib/logic/player/content.dart
+++ b/lib/logic/player/content.dart
@@ -437,6 +437,7 @@ class ContentControl extends Control {
         stack,
         reason: 'in re-fetch ${contentType.name}',
       );
+      ShowFunctions.instance.showToast(msg: staticl10n.oopsErrorOccurred);
     }
   }
 

--- a/lib/logic/player/content.dart
+++ b/lib/logic/player/content.dart
@@ -381,54 +381,62 @@ class ContentControl extends Control {
     if (disposed.value) {
       return;
     }
-    switch (contentType) {
-      case ContentType.song:
-        state.allSongs.setSongs((await SweyerPlugin.instance.retrieveSongs(Song.fromMap)).toList());
-        if (_empty) {
-          dispose();
-          return;
-        }
-        sort(emitChangeEvent: false, contentType: contentType);
-        if (updateQueues) {
-          QueueControl.instance.removeObsolete(emitChangeEvent: false);
-        }
-        break;
-      case ContentType.album:
-        state.albums = await SweyerPlugin.instance.retrieveAlbums(Album.fromMap);
-        if (disposed.value) {
-          return;
-        }
-        final origin = QueueControl.instance.state.origin;
-        if (origin is Album && state.albums[origin.id] == null) {
-          QueueControl.instance.resetQueueAsFallback();
-        }
-        sort(emitChangeEvent: false, contentType: contentType);
-        break;
-      case ContentType.playlist:
-        state.playlists = (await SweyerPlugin.instance.retrievePlaylists(Playlist.fromMap)).toList();
-        if (disposed.value) {
-          return;
-        }
-        final origin = QueueControl.instance.state.origin;
-        if (origin is Playlist && state.playlists.firstWhereOrNull((el) => el == origin) == null) {
-          QueueControl.instance.resetQueueAsFallback();
-        }
-        sort(emitChangeEvent: false, contentType: contentType);
-        break;
-      case ContentType.artist:
-        state.artists = (await SweyerPlugin.instance.retrieveArtists(Artist.fromMap)).toList();
-        if (disposed.value) {
-          return;
-        }
-        final origin = QueueControl.instance.state.origin;
-        if (origin is Artist && state.artists.firstWhereOrNull((el) => el == origin) == null) {
-          QueueControl.instance.resetQueueAsFallback();
-        }
-        sort(emitChangeEvent: false, contentType: contentType);
-        break;
-    }
-    if (emitChangeEvent) {
-      emitContentChange();
+    try {
+      switch (contentType) {
+        case ContentType.song:
+          state.allSongs.setSongs((await SweyerPlugin.instance.retrieveSongs(Song.fromMap)).toList());
+          if (_empty) {
+            dispose();
+            return;
+          }
+          sort(emitChangeEvent: false, contentType: contentType);
+          if (updateQueues) {
+            QueueControl.instance.removeObsolete(emitChangeEvent: false);
+          }
+          break;
+        case ContentType.album:
+          state.albums = await SweyerPlugin.instance.retrieveAlbums(Album.fromMap);
+          if (disposed.value) {
+            return;
+          }
+          final origin = QueueControl.instance.state.origin;
+          if (origin is Album && state.albums[origin.id] == null) {
+            QueueControl.instance.resetQueueAsFallback();
+          }
+          sort(emitChangeEvent: false, contentType: contentType);
+          break;
+        case ContentType.playlist:
+          state.playlists = (await SweyerPlugin.instance.retrievePlaylists(Playlist.fromMap)).toList();
+          if (disposed.value) {
+            return;
+          }
+          final origin = QueueControl.instance.state.origin;
+          if (origin is Playlist && state.playlists.firstWhereOrNull((el) => el == origin) == null) {
+            QueueControl.instance.resetQueueAsFallback();
+          }
+          sort(emitChangeEvent: false, contentType: contentType);
+          break;
+        case ContentType.artist:
+          state.artists = (await SweyerPlugin.instance.retrieveArtists(Artist.fromMap)).toList();
+          if (disposed.value) {
+            return;
+          }
+          final origin = QueueControl.instance.state.origin;
+          if (origin is Artist && state.artists.firstWhereOrNull((el) => el == origin) == null) {
+            QueueControl.instance.resetQueueAsFallback();
+          }
+          sort(emitChangeEvent: false, contentType: contentType);
+          break;
+      }
+      if (emitChangeEvent) {
+        emitContentChange();
+      }
+    } on SweyerPluginException catch (ex, stack) {
+      FirebaseCrashlytics.instance.recordError(
+        ex,
+        stack,
+        reason: 'in re-fetch ${contentType.name}',
+      );
     }
   }
 

--- a/lib/logic/player/music_player.dart
+++ b/lib/logic/player/music_player.dart
@@ -757,8 +757,9 @@ class MusicPlayer extends AudioPlayer {
       if (e is PlayerInterruptedException || e is PlatformException && e.code == 'abort') {
         // Do nothing
       } else if (e is PlayerException) {
-        final message = getl10n(AppRouter.instance.navigatorKey.currentContext!).playbackError;
-        ShowFunctions.instance.showToast(msg: message);
+        final context = AppRouter.instance.navigatorKey.currentContext;
+        final l10n = context != null ? getl10n(context) : staticl10n;
+        ShowFunctions.instance.showToast(msg: l10n.playbackError);
         playNext(song: song);
         ContentControl.instance.state.allSongs.remove(song);
         ContentControl.instance.refetch(ContentType.song);

--- a/lib/widgets/show_functions.dart
+++ b/lib/widgets/show_functions.dart
@@ -104,7 +104,11 @@ class ShowFunctions extends NFShowFunctions {
   /// From that snack bar will be possible to proceed to special alert to see the error details with the ability to copy them.
   /// [errorDetails] string to show in the alert
   void showError({required String errorDetails}) {
-    final context = AppRouter.instance.navigatorKey.currentContext!;
+    final context = AppRouter.instance.navigatorKey.currentContext;
+    if (context == null) {
+      debugPrint(errorDetails);
+      return;
+    }
     final l10n = getl10n(context);
     final theme = Theme.of(context);
     final globalKey = GlobalKey<NFSnackbarEntryState>();

--- a/sweyer_plugin/lib/sweyer_plugin_method_channel.dart
+++ b/sweyer_plugin/lib/sweyer_plugin_method_channel.dart
@@ -54,7 +54,7 @@ class MethodChannelSweyerPlugin extends SweyerPluginPlatform {
   @override
   Future<void> cancelAlbumArtLoad({required String id}) async {
     try {
-      return methodChannel.invokeMethod<void>('cancelAlbumArtLoading', {'id': id});
+      return await methodChannel.invokeMethod<void>('cancelAlbumArtLoading', {'id': id});
     } on PlatformException catch (error) {
       throw _convertCommonExceptions('cancelAlbumArtLoading failed', error);
     }
@@ -63,7 +63,7 @@ class MethodChannelSweyerPlugin extends SweyerPluginPlatform {
   @override
   Future<void> fixAlbumArt(int albumId) async {
     try {
-      return methodChannel.invokeMethod<void>('fixAlbumArt', {'id': albumId});
+      return await methodChannel.invokeMethod<void>('fixAlbumArt', {'id': albumId});
     } on PlatformException catch (error) {
       throw _convertCommonExceptions('fixAlbumArt failed', error);
     }
@@ -170,7 +170,7 @@ class MethodChannelSweyerPlugin extends SweyerPluginPlatform {
   @override
   Future<void> removePlaylists(List<int> playlistIds) async {
     try {
-      return methodChannel.invokeMethod<void>('removePlaylists', {'ids': playlistIds});
+      return await methodChannel.invokeMethod<void>('removePlaylists', {'ids': playlistIds});
     } on PlatformException catch (error) {
       throw _convertCommonExceptions('removePlaylists failed', error);
     }

--- a/sweyer_plugin/lib/sweyer_plugin_method_channel.dart
+++ b/sweyer_plugin/lib/sweyer_plugin_method_channel.dart
@@ -11,7 +11,6 @@ enum SweyerMethodChannelExceptionCode {
   /// On Android 30 requests like `MediaStore.createDeletionRequest` require
   /// calling `startIntentSenderForResult`, which might throw this exception.
   intentSender('INTENT_SENDER_ERROR'),
-
   io('IO_ERROR'),
 
   /// API is unavailable on current SDK level.
@@ -53,36 +52,67 @@ class MethodChannelSweyerPlugin extends SweyerPluginPlatform {
   }
 
   @override
-  Future<void> cancelAlbumArtLoad({required String id}) async => methodChannel.invokeMethod<void>(
-        'cancelAlbumArtLoading',
-        {'id': id},
-      );
+  Future<void> cancelAlbumArtLoad({required String id}) async {
+    try {
+      return methodChannel.invokeMethod<void>('cancelAlbumArtLoading', {'id': id});
+    } on PlatformException catch (error) {
+      throw _convertCommonExceptions('cancelAlbumArtLoading failed', error);
+    }
+  }
 
   @override
-  Future<void> fixAlbumArt(int albumId) async => methodChannel.invokeMethod<void>(
-        'fixAlbumArt',
-        {'id': albumId},
-      );
+  Future<void> fixAlbumArt(int albumId) async {
+    try {
+      return methodChannel.invokeMethod<void>('fixAlbumArt', {'id': albumId});
+    } on PlatformException catch (error) {
+      throw _convertCommonExceptions('fixAlbumArt failed', error);
+    }
+  }
 
   @override
-  Future<Iterable<Map<String, dynamic>>> retrieveSongs() async =>
-      (await methodChannel.invokeListMethod<Map>('retrieveSongs'))!.map(Map.castFrom);
+  Future<Iterable<Map<String, dynamic>>> retrieveSongs() async {
+    try {
+      return (await methodChannel.invokeListMethod<Map>('retrieveSongs'))!.map(Map.castFrom);
+    } on PlatformException catch (error) {
+      throw _convertCommonExceptions('retrieveSongs failed', error);
+    }
+  }
 
   @override
-  Future<Iterable<Map<String, dynamic>>> retrieveAlbums() async =>
-      (await methodChannel.invokeListMethod<Map>('retrieveAlbums'))!.map(Map.castFrom);
+  Future<Iterable<Map<String, dynamic>>> retrieveAlbums() async {
+    try {
+      return (await methodChannel.invokeListMethod<Map>('retrieveAlbums'))!.map(Map.castFrom);
+    } on PlatformException catch (error) {
+      throw _convertCommonExceptions('retrieveAlbums failed', error);
+    }
+  }
 
   @override
-  Future<Iterable<Map<String, dynamic>>> retrievePlaylists() async =>
-      (await methodChannel.invokeListMethod<Map>('retrievePlaylists'))!.map(Map.castFrom);
+  Future<Iterable<Map<String, dynamic>>> retrievePlaylists() async {
+    try {
+      return (await methodChannel.invokeListMethod<Map>('retrievePlaylists'))!.map(Map.castFrom);
+    } on PlatformException catch (error) {
+      throw _convertCommonExceptions('retrievePlaylists failed', error);
+    }
+  }
 
   @override
-  Future<Iterable<Map<String, dynamic>>> retrieveArtists() async =>
-      (await methodChannel.invokeListMethod<Map>('retrieveArtists'))!.map(Map.castFrom);
+  Future<Iterable<Map<String, dynamic>>> retrieveArtists() async {
+    try {
+      return (await methodChannel.invokeListMethod<Map>('retrieveArtists'))!.map(Map.castFrom);
+    } on PlatformException catch (error) {
+      throw _convertCommonExceptions('retrieveArtists failed', error);
+    }
+  }
 
   @override
-  Future<Iterable<Map<String, dynamic>>> retrieveGenres() async =>
-      (await methodChannel.invokeListMethod<Map>('retrieveGenres'))!.map(Map.castFrom);
+  Future<Iterable<Map<String, dynamic>>> retrieveGenres() async {
+    try {
+      return (await methodChannel.invokeListMethod<Map>('retrieveGenres'))!.map(Map.castFrom);
+    } on PlatformException catch (error) {
+      throw _convertCommonExceptions('retrieveGenres failed', error);
+    }
+  }
 
   @override
   Future<bool> setSongsFavorite(List<int> songsIds, bool value) async {
@@ -138,8 +168,13 @@ class MethodChannelSweyerPlugin extends SweyerPluginPlatform {
   }
 
   @override
-  Future<void> removePlaylists(List<int> playlistIds) async =>
-      methodChannel.invokeMethod<void>('removePlaylists', {'ids': playlistIds});
+  Future<void> removePlaylists(List<int> playlistIds) async {
+    try {
+      return methodChannel.invokeMethod<void>('removePlaylists', {'ids': playlistIds});
+    } on PlatformException catch (error) {
+      throw _convertCommonExceptions('removePlaylists failed', error);
+    }
+  }
 
   @override
   Future<void> insertSongsInPlaylist({
@@ -165,26 +200,21 @@ class MethodChannelSweyerPlugin extends SweyerPluginPlatform {
   }
 
   @override
-  Future<bool> moveSongInPlaylist({required int playlistId, required int from, required int to}) async =>
-      (await methodChannel.invokeMethod<bool>(
+  Future<bool> moveSongInPlaylist({required int playlistId, required int from, required int to}) async {
+    try {
+      return (await methodChannel.invokeMethod<bool>(
         'moveSongInPlaylist',
-        {
-          'id': playlistId,
-          'from': from,
-          'to': to,
-        },
+        {'id': playlistId, 'from': from, 'to': to},
       ))!;
+    } on PlatformException catch (error) {
+      throw _convertCommonExceptions('moveSongInPlaylist failed', error);
+    }
+  }
 
   @override
   Future<void> removeFromPlaylistAt({required List<int> indexes, required int playlistId}) async {
     try {
-      return await methodChannel.invokeMethod<void>(
-        'removeFromPlaylistAt',
-        {
-          'id': playlistId,
-          'indexes': indexes,
-        },
-      );
+      return await methodChannel.invokeMethod<void>('removeFromPlaylistAt', {'id': playlistId, 'indexes': indexes});
     } on PlatformException catch (error) {
       if (error.code == SweyerMethodChannelExceptionCode.playlistNotExists.value) {
         throw PlaylistNotExistException(playlistId, cause: error);
@@ -194,7 +224,13 @@ class MethodChannelSweyerPlugin extends SweyerPluginPlatform {
   }
 
   @override
-  Future<bool> isIntentActionView() async => (await methodChannel.invokeMethod<bool>('isIntentActionView'))!;
+  Future<bool> isIntentActionView() async {
+    try {
+      return (await methodChannel.invokeMethod<bool>('isIntentActionView'))!;
+    } on PlatformException catch (error) {
+      throw _convertCommonExceptions('isIntentActionView failed', error);
+    }
+  }
 
   SweyerPluginException _convertCommonExceptions(String message, PlatformException error) {
     if (error.code == SweyerMethodChannelExceptionCode.sdk.value) {


### PR DESCRIPTION
This fixes a few problem that would cause the app to get stuck on the splash screen, when there was an error during startup.
I think it is a better user experience when we continue and show the app UI, even though some content might be missing because of the exception.

*This depends on and includes changes from #89 and will be kept as a draft until it is merged.*