### PR TITLE
Add CI job to build APK

### DIFF
--- a/.github/workflows/build_and_test/action.yml
+++ b/.github/workflows/build_and_test/action.yml
@@ -47,19 +47,6 @@ runs:
         path: test/golden/failures
         if-no-files-found: ignore
 
-    - name: 💾 Cache Android SDK
-      uses: actions/cache@v4
-      with:
-        key: android-sdk-${{inputs.flutter_version}}-${{inputs.flutter_channel}}
-        path: |
-          /home/runner/.android
-          /usr/local/lib/android/sdk/emulator
-          /usr/local/lib/android/sdk/platform-tools
-          /usr/local/lib/android/sdk/tools
-          /usr/local/lib/android/sdk/build-tools/30.0.3
-          /usr/local/lib/android/sdk/platforms/android-30
-          /usr/local/lib/android/sdk/platforms/android-28
-
     - name: 💾 Cache Gradle
       uses: actions/cache@v4
       with:
@@ -68,7 +55,4 @@ runs:
 
     - name: 🔨 Build Apk
       shell: bash
-      run: |
-        ls /usr/local/lib/android/sdk/licenses
-        flutter build apk --debug
-        ls /usr/local/lib/android/sdk/licenses
+      run: flutter build apk --debug

--- a/.github/workflows/build_and_test/action.yml
+++ b/.github/workflows/build_and_test/action.yml
@@ -47,6 +47,15 @@ runs:
         path: test/golden/failures
         if-no-files-found: ignore
 
+    - name: 💾 Cache android SDK
+      uses: actions/cache@v2
+      id: android-sdk
+      with:
+        key: android-sdk
+        path: |
+          /usr/local/lib/android/adk
+          ~/.android
+
     - name: 🔨 Build Apk
       shell: bash
       run: flutter build apk --debug

--- a/.github/workflows/build_and_test/action.yml
+++ b/.github/workflows/build_and_test/action.yml
@@ -35,10 +35,6 @@ runs:
         very_good --analytics false
         very_good packages get --recursive
 
-    - name: 🔨 Build Apk
-      shell: bash
-      run: flutter build apk --debug
-
     - name: 🧪 Run Tests
       shell: bash
       run: flutter test --no-pub --test-randomize-ordering-seed random ${{inputs.testing_arguments}}
@@ -50,3 +46,7 @@ runs:
         name: golden-test-failures
         path: test/golden/failures
         if-no-files-found: ignore
+
+    - name: 🔨 Build Apk
+      shell: bash
+      run: flutter build apk --debug

--- a/.github/workflows/build_and_test/action.yml
+++ b/.github/workflows/build_and_test/action.yml
@@ -47,14 +47,13 @@ runs:
         path: test/golden/failures
         if-no-files-found: ignore
 
-    - name: 💾 Cache android SDK
+    - name: 💾 Cache Android SDK
       uses: actions/cache@v4
-      id: android-sdk
       with:
-        key: android-sdk
+        key: android-sdk-${{inputs.flutter_version}}-${{inputs.flutter_channel}}
         path: |
-          /usr/local/lib/android/adk
-          ~/.android
+          /usr/local/lib/android/sdk
+          /home/runner/.android
           /home/runner/.gradle
 
     - name: 🔨 Build Apk

--- a/.github/workflows/build_and_test/action.yml
+++ b/.github/workflows/build_and_test/action.yml
@@ -46,13 +46,3 @@ runs:
         name: golden-test-failures
         path: test/golden/failures
         if-no-files-found: ignore
-
-    - name: 💾 Cache Gradle
-      uses: actions/cache@v4
-      with:
-        key: gradle
-        path: /home/runner/.gradle
-
-    - name: 🔨 Build Apk
-      shell: bash
-      run: flutter build apk --debug

--- a/.github/workflows/build_and_test/action.yml
+++ b/.github/workflows/build_and_test/action.yml
@@ -55,6 +55,7 @@ runs:
         path: |
           /usr/local/lib/android/adk
           ~/.android
+          /home/runner/.gradle
 
     - name: 🔨 Build Apk
       shell: bash

--- a/.github/workflows/build_and_test/action.yml
+++ b/.github/workflows/build_and_test/action.yml
@@ -35,6 +35,10 @@ runs:
         very_good --analytics false
         very_good packages get --recursive
 
+    - name: 🔨 Build Apk
+      shell: bash
+      run: flutter build apk --debug
+
     - name: 🧪 Run Tests
       shell: bash
       run: flutter test --no-pub --test-randomize-ordering-seed random ${{inputs.testing_arguments}}

--- a/.github/workflows/build_and_test/action.yml
+++ b/.github/workflows/build_and_test/action.yml
@@ -71,3 +71,4 @@ runs:
       run: |
         ls /usr/local/lib/android/sdk/licenses
         flutter build apk --debug
+        ls /usr/local/lib/android/sdk/licenses

--- a/.github/workflows/build_and_test/action.yml
+++ b/.github/workflows/build_and_test/action.yml
@@ -52,9 +52,20 @@ runs:
       with:
         key: android-sdk-${{inputs.flutter_version}}-${{inputs.flutter_channel}}
         path: |
-          /usr/local/lib/android/sdk
           /home/runner/.android
-          /home/runner/.gradle
+          /usr/local/lib/android/sdk/emulator
+          /usr/local/lib/android/sdk/licenses
+          /usr/local/lib/android/sdk/platform-tools
+          /usr/local/lib/android/sdk/tools
+          /usr/local/lib/android/sdk/build-tools/30.0.3
+          /usr/local/lib/android/sdk/platforms/android-30
+          /usr/local/lib/android/sdk/platforms/android-28
+
+    - name: 💾 Cache Gradle
+      uses: actions/cache@v4
+      with:
+        key: gradle
+        path: /home/runner/.gradle
 
     - name: 🔨 Build Apk
       shell: bash

--- a/.github/workflows/build_and_test/action.yml
+++ b/.github/workflows/build_and_test/action.yml
@@ -54,7 +54,6 @@ runs:
         path: |
           /home/runner/.android
           /usr/local/lib/android/sdk/emulator
-          /usr/local/lib/android/sdk/licenses
           /usr/local/lib/android/sdk/platform-tools
           /usr/local/lib/android/sdk/tools
           /usr/local/lib/android/sdk/build-tools/30.0.3
@@ -69,4 +68,6 @@ runs:
 
     - name: 🔨 Build Apk
       shell: bash
-      run: flutter build apk --debug
+      run: |
+        ls /usr/local/lib/android/sdk/licenses
+        flutter build apk --debug

--- a/.github/workflows/build_and_test/action.yml
+++ b/.github/workflows/build_and_test/action.yml
@@ -48,7 +48,7 @@ runs:
         if-no-files-found: ignore
 
     - name: 💾 Cache android SDK
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: android-sdk
       with:
         key: android-sdk

--- a/.github/workflows/build_executables.yml
+++ b/.github/workflows/build_executables.yml
@@ -31,10 +31,10 @@ jobs:
 
       - name: 🔨 Build Apk
         shell: bash
-        run: flutter build apk --debug
+        run: flutter build apk --profile
 
       - name: 📁 Save executables
         uses: actions/upload-artifact@v4
         with:
           name: Android Apk
-          path: build/app/outputs/flutter-apk/app-debug.apk
+          path: build/app/outputs/flutter-apk/app-profile.apk

--- a/.github/workflows/build_executables.yml
+++ b/.github/workflows/build_executables.yml
@@ -1,0 +1,40 @@
+name: Build Sweyer executables
+on: 
+  workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📚 Git Checkout
+        uses: actions/checkout@v3
+
+      - name: 🐦 Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.7.12
+          channel: stable
+          cache: true
+
+      - name: 📦 Install Dependencies
+        shell: bash
+        run: |
+          flutter pub global activate very_good_cli
+          very_good --analytics false
+          very_good packages get --recursive
+
+      - name: 💾 Cache Gradle
+        uses: actions/cache@v4
+        with:
+          key: gradle
+          path: /home/runner/.gradle
+
+      - name: 🔨 Build Apk
+        shell: bash
+        run: flutter build apk --debug
+
+      - name: 📁 Save executables
+        uses: actions/upload-artifact@v3
+        with:
+          name: android-apk
+          path: build/app/outputs/flutter-apk/app-debug.apk

--- a/.github/workflows/build_executables.yml
+++ b/.github/workflows/build_executables.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📚 Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
@@ -34,7 +34,7 @@ jobs:
         run: flutter build apk --debug
 
       - name: 📁 Save executables
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: android-apk
+          name: Android Apk
           path: build/app/outputs/flutter-apk/app-debug.apk

--- a/.github/workflows/build_executables.yml
+++ b/.github/workflows/build_executables.yml
@@ -1,6 +1,6 @@
 name: Build Sweyer executables
-on: 
-  workflow_dispatch
+on:
+  pull_request
 
 jobs:
   build:

--- a/.github/workflows/sweyer.yml
+++ b/.github/workflows/sweyer.yml
@@ -8,8 +8,8 @@ jobs:
       - name: 📚 Git Checkout
         uses: actions/checkout@v3
 
-      - name: 🏗 Build and test Sweyer
-        uses: ./.github/workflows/build_and_test
+      - name: 🧪 Test Sweyer
+        uses: ./.github/workflows/test
         with:
           testing_arguments: --coverage
 

--- a/.github/workflows/sweyer_release.yml
+++ b/.github/workflows/sweyer_release.yml
@@ -15,9 +15,9 @@ jobs:
       - name: 📚 Git Checkout
         uses: actions/checkout@v3
 
-      - name: 🏗 Build and test Sweyer
+      - name: 🧪 Test Sweyer
         if: ${{ github.event.inputs.skip-tests == 'false' }}
-        uses: ./.github/workflows/build_and_test
+        uses: ./.github/workflows/test
         with:
           testing_arguments: --coverage
 

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -1,8 +1,8 @@
 # Modified very_good_workflows workflow, see ThirdPartyNotices.txt for license
 # https://github.com/VeryGoodOpenSource/very_good_workflows/blob/c66b5434b3428fb5c3d5101492f173b206821850/.github/workflows/flutter_package.yml
 
-name: 🏗 Build and test Sweyer
-description: Build Sweyer and then test it.
+name: 🧪 Test Sweyer
+description: Run the Sweyer tests.
 
 inputs:
   flutter_channel:

--- a/.github/workflows/update_goldens.yml
+++ b/.github/workflows/update_goldens.yml
@@ -17,8 +17,8 @@ jobs:
       - name: 📚 Git Checkout
         uses: actions/checkout@v3
 
-      - name: 🏗 Build and test Sweyer
-        uses: ./.github/workflows/build_and_test
+      - name: 🧪 Test Sweyer
+        uses: ./.github/workflows/test
         with:
           testing_arguments: --update-goldens
 


### PR DESCRIPTION
It would be good if CI would notify us if a change would break building the APK.

Unfortunately this increases our CI runtime from ~2min 30sec to ~4min 30sec. I already added a cache for Gradle, which helped a ton, but caching the Android SDK is not helping. 