### PR TITLE
Fix null exception when filtering while searching

### DIFF
--- a/lib/routes/home_route/search_route.dart
+++ b/lib/routes/home_route/search_route.dart
@@ -209,7 +209,7 @@ class _SearchStateDelegate {
     // the `targetRenderObject` invisible.
     // Also see https://github.com/flutter/flutter/issues/65100
     RenderObject? targetRenderObject;
-    ScrollableState? scrollable = Scrollable.of(context);
+    ScrollableState? scrollable = Scrollable.maybeOf(context);
     while (scrollable != null) {
       futures.add(_ensureVisible(
         scrollable.position,
@@ -223,7 +223,7 @@ class _SearchStateDelegate {
 
       targetRenderObject = targetRenderObject ?? context.findRenderObject();
       context = scrollable.context;
-      scrollable = Scrollable.of(context);
+      scrollable = Scrollable.maybeOf(context);
     }
 
     if (futures.isEmpty || duration == Duration.zero) {


### PR DESCRIPTION
I guess `Scrollable.of` was nullable before Flutter switched to sound null safety. `Scrollable.maybeOf` does the same thing but doesn't error when no scrollable was found, which is what we want here.

Fixes #128.