### PR TITLE
Add some horizontal padding to the artist name on the player screen

### DIFF
--- a/lib/routes/home_route/player_route.dart
+++ b/lib/routes/home_route/player_route.dart
@@ -1022,6 +1022,8 @@ class _TrackShowcaseState extends State<TrackShowcase> with TickerProviderStateM
           padding: EdgeInsets.only(
             top: 2.0,
             bottom: 30.0 / textScaleFactor,
+            right: 20,
+            left: 20,
           ),
           child: ArtistWidget(
             artist: currentSong.artist,


### PR DESCRIPTION
When the artist name of a song is very large, if filles the entire width of the screen right up to the border.
This feels a bit weird and unpolished, so I added a `20px` padding (The song title has `30px` padding).

| Before | After |
| ------- | ------ |
| ![Artist text - before](https://github.com/user-attachments/assets/9a7410d6-46c1-4b5d-afc5-8170f2f643e1) | ![Artist text - after](https://github.com/user-attachments/assets/3be5ca7c-a1c1-4da7-9f9a-84b4eda40d80) |
