### PR TITLE
Fix marking songs as favourite with the Android system

### DIFF
--- a/sweyer_plugin/android/src/main/kotlin/com/nt4f04und/sweyer/sweyer_plugin/SweyerPlugin.kt
+++ b/sweyer_plugin/android/src/main/kotlin/com/nt4f04und/sweyer/sweyer_plugin/SweyerPlugin.kt
@@ -221,7 +221,7 @@ class SweyerPlugin : FlutterPlugin, MethodCallHandler, ActivityAware, ActivityRe
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                         this.result = result
                         val value = call.argument<Boolean>("value")!!
-                        val songIds = call.argument<ArrayList<ArrayList<Any>>>("songIds")!!
+                        val songIds = call.argument<ArrayList<Any>>("songIds")!!
                         val uris = ArrayList<Uri>()
                         for (songId in songIds) {
                             val id = getLong(songId)


### PR DESCRIPTION
The original Java code also had the wrong type, but Kotlin is much more strict so this became a runtime error when we switched to Kotlin.

<details><summary>This fixes the <code>MethodChannelSweyerPlugin.setSongsFavorite</code> crash captured in Crashlytics</summary>

```
          Non-fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: PUa: setSongsFavorite failed

Caused by:
PlatformException(UNEXPECTED_ERROR, java.lang.Integer cannot be cast to java.util.ArrayList, java.lang.ClassCastException: java.lang.Integer cannot be cast to java.util.ArrayList
	at b5.r0.F(Unknown Source:377)
	at z5.k$a.a(Unknown Source:17)
	at n5.c.l(Unknown Source:18)
	at n5.c.m(Unknown Source:40)
	at n5.c.i(Unknown Source:0)
	at n5.b.run(Unknown Source:12)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:233)
	at android.os.Looper.loop(Looper.java:344)
	at android.app.ActivityThread.main(ActivityThread.java:8200)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:589)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1071)
, null). Error thrown in setSongsFavorite.
#00 pc 0x6d274b com.nt4f04und.sweyer (MethodChannelSweyerPlugin.setSongsFavorite [sweyer_plugin_method_channel.dart:128]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#01 pc 0x691a5f com.nt4f04und.sweyer (_SuspendState._createAsyncCallbacks.errorCallback [async_patch.dart:201]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#02 pc 0x695f07 com.nt4f04und.sweyer (_FutureListener.handleError [zone.dart:1665]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#03 pc 0x695c3b com.nt4f04und.sweyer (Future._propagateToListeners.handleError [future_impl.dart:779]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#04 pc 0x1bed73 com.nt4f04und.sweyer (Future._propagateToListeners [future_impl.dart:800]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#05 pc 0x1be83b com.nt4f04und.sweyer (Future._completeError [future_impl.dart:575]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#06 pc 0x690623 com.nt4f04und.sweyer (_SuspendState._handleException [async_patch.dart:393]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#07 pc 0x690b6f com.nt4f04und.sweyer (_SuspendState._createAsyncStarCallback.<anonymous closure> [async_patch.dart:353]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#08 pc 0x1bff37 com.nt4f04und.sweyer (_FutureListener.handleValue [zone.dart:1660]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#09 pc 0x6964cb com.nt4f04und.sweyer (Future._propagateToListeners.handleValueCallback [future_impl.dart:767]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#10 pc 0x1bed3b com.nt4f04und.sweyer (Future._propagateToListeners [future_impl.dart:796]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#11 pc 0x1c3d97 com.nt4f04und.sweyer (Future._completeWithValue [future_impl.dart:567]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#12 pc 0x1c093b com.nt4f04und.sweyer (Future._asyncCompleteWithValue.<anonymous closure> [future_impl.dart:640]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#13 pc 0x1be40b com.nt4f04und.sweyer (_microtaskLoop [schedule_microtask.dart:40]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#14 pc 0x69553f com.nt4f04und.sweyer (_startMicrotaskLoop [schedule_microtask.dart:49]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#15 pc 0x1be37f com.nt4f04und.sweyer (_startMicrotaskLoop [schedule_microtask.dart:44]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
```
</details> 