### PR TITLE
Fix deselect all

### DIFF
--- a/lib/logic/models/selection_entry.dart
+++ b/lib/logic/models/selection_entry.dart
@@ -27,13 +27,23 @@ class SelectionEntry<T extends Content> {
           origin: selectionRouteOf(context) && song.origin is DuplicatingSongOriginMixin ? song.origin : null,
         ) as SelectionEntry<T>;
       case ContentType.album:
-      case ContentType.playlist:
-      case ContentType.artist:
-        return SelectionEntry<T>(
+        return SelectionEntry<Album>(
           index: index,
-          data: content,
+          data: content as Album,
           origin: null,
-        );
+        ) as SelectionEntry<T>;
+      case ContentType.playlist:
+        return SelectionEntry<Playlist>(
+          index: index,
+          data: content as Playlist,
+          origin: null,
+        ) as SelectionEntry<T>;
+      case ContentType.artist:
+        return SelectionEntry<Artist>(
+          index: index,
+          data: content as Artist,
+          origin: null,
+        ) as SelectionEntry<T>;
     }
   }
 

--- a/lib/logic/player/content.dart
+++ b/lib/logic/player/content.dart
@@ -988,16 +988,19 @@ class ContentUtils {
     final List<SelectionEntry<Playlist>> playlists = [];
     final List<SelectionEntry<Artist>> artists = [];
     for (final entry in data) {
-      if (entry is SelectionEntry<Song>) {
-        songs.add(entry);
-      } else if (entry is SelectionEntry<Album>) {
-        albums.add(entry);
-      } else if (entry is SelectionEntry<Playlist>) {
-        playlists.add(entry);
-      } else if (entry is SelectionEntry<Artist>) {
-        artists.add(entry);
-      } else {
-        throw UnimplementedError();
+      switch (entry.data.type) {
+        case ContentType.song:
+          songs.add(entry as SelectionEntry<Song>);
+          break;
+        case ContentType.album:
+          albums.add(entry as SelectionEntry<Album>);
+          break;
+        case ContentType.playlist:
+          playlists.add(entry as SelectionEntry<Playlist>);
+          break;
+        case ContentType.artist:
+          artists.add(entry as SelectionEntry<Artist>);
+          break;
       }
     }
     if (sort) {

--- a/lib/widgets/selection.dart
+++ b/lib/widgets/selection.dart
@@ -2342,7 +2342,7 @@ class SelectAllSelectionAction<T extends Content> extends StatelessWidget {
       final first = all.first;
       assert(all.every((el) => el.runtimeType == first.runtimeType));
 
-      final selectedOfThisType = controller.data.where((el) => el.runtimeType == entryFactory(first, 0).runtimeType);
+      final selectedOfThisType = controller.data.where((el) => el.data.type == entryFactory(first, 0).data.type);
       bool allSelected = true;
       for (int i = 0; i < all.length; i++) {
         if (!selectedOfThisType.contains(entryFactory(all[i], i))) {


### PR DESCRIPTION
Fixes https://github.com/nt4f04uNd/sweyer/issues/98

Problem was on this line
https://github.com/nt4f04uNd/sweyer/blob/fix/98/playlist-deselect-all/lib/routes/home_route/search_route.dart#L619

Also, here this code couldn't pick up the proper `runtimeType`

I refactored both places for double-bulletproof + other place where we were checking runtimeType, instead of `contentType`

Opened an issue to remove all usages of runtimeType
https://github.com/nt4f04uNd/sweyer/issues/137