### PR TITLE
Adjust worflow runs

### DIFF
--- a/.github/workflows/build_executables.yml
+++ b/.github/workflows/build_executables.yml
@@ -1,6 +1,10 @@
 name: Build Sweyer executables
 on:
-  pull_request
+  pull_request:
+  push:
+    branches:    
+      - main
+      - 'releases/**'
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,10 @@
-name: Sweyer PR workflow
-on: [push, pull_request]
+name: Run Sweyer tests
+on:
+  pull_request:
+  push:
+    branches:    
+      - main
+      - 'releases/**'
 
 jobs:
   build:


### PR DESCRIPTION
1. Rename workflows for more clarity
2. Run builds only on push to main branches (this removes double builds in PRs)
3. Enable executable builds on push to main branches