### PR TITLE
Use getContentUri on newer Android versions

### DIFF
--- a/sweyer_plugin/android/src/main/kotlin/com/nt4f04und/sweyer/sweyer_plugin/handlers/FetchHandler.kt
+++ b/sweyer_plugin/android/src/main/kotlin/com/nt4f04und/sweyer/sweyer_plugin/handlers/FetchHandler.kt
@@ -32,7 +32,12 @@ object FetchHandler {
     }
 
     fun retrieveSongs(resolver: ContentResolver): ArrayList<MutableMap<String, Any?>> {
-        return executeQuery(resolver, MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, songsSelection, buildMap {
+        val contentUrl = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL)
+        } else {
+            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
+        }
+        return executeQuery(resolver, contentUrl, songsSelection, buildMap {
             put(MediaStore.Audio.Media._ID, "id" to { cursor, index -> cursor.getInt(index) })
             put(MediaStore.Audio.Media.ALBUM, "album" to { cursor, index -> cursor.getString(index) })
             put(MediaStore.Audio.Media.ALBUM_ID, "albumId" to { cursor, index -> cursor.getInt(index) })
@@ -115,10 +120,15 @@ object FetchHandler {
         } else {
             "artist_id"
         }
+        val contentUrl = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            MediaStore.Audio.Albums.getContentUri(MediaStore.VOLUME_EXTERNAL)
+        } else {
+            MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI
+        }
         try {
             return executeQuery(
                 resolver,
-                MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI,
+                contentUrl,
                 MediaStore.Audio.Albums.ALBUM + " IS NOT NULL",
                 mapOf(
                     MediaStore.Audio.Albums._ID to Pair("id") { cursor, index -> cursor.getInt(index) },
@@ -138,7 +148,7 @@ object FetchHandler {
         } catch (ignored: Throwable) {
             return executeQuery(
                 resolver,
-                MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI,
+                contentUrl,
                 MediaStore.Audio.Albums.ALBUM + " IS NOT NULL",
                 mapOf(
                     MediaStore.Audio.Albums._ID to Pair("id") { cursor, index -> cursor.getInt(index) },
@@ -159,9 +169,14 @@ object FetchHandler {
 
     fun retrievePlaylists(resolver: ContentResolver): ArrayList<MutableMap<String, Any?>> {
         val memberProjection = arrayOf(MediaStore.Audio.Playlists.Members.AUDIO_ID)
+        val contentUrl = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            MediaStore.Audio.Playlists.getContentUri(MediaStore.VOLUME_EXTERNAL)
+        } else {
+            MediaStore.Audio.Playlists.EXTERNAL_CONTENT_URI
+        }
         return executeQuery(
             resolver,
-            MediaStore.Audio.Playlists.EXTERNAL_CONTENT_URI,
+            contentUrl,
             MediaStore.Audio.Playlists.NAME + " IS NOT NULL",
             mapOf(
                 MediaStore.Audio.Playlists._ID to Pair("id") { cursor, index -> cursor.getLong(index) },
@@ -191,9 +206,14 @@ object FetchHandler {
     }
 
     fun retrieveArtists(resolver: ContentResolver): ArrayList<MutableMap<String, Any?>> {
+        val contentUrl = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            MediaStore.Audio.Artists.getContentUri(MediaStore.VOLUME_EXTERNAL)
+        } else {
+            MediaStore.Audio.Artists.EXTERNAL_CONTENT_URI
+        }
         return executeQuery(
             resolver,
-            MediaStore.Audio.Artists.EXTERNAL_CONTENT_URI,
+            contentUrl,
             MediaStore.Audio.Artists.ARTIST + " IS NOT NULL",
             mapOf(
                 MediaStore.Audio.Artists._ID to Pair("id") { cursor, index -> cursor.getInt(index) },
@@ -210,9 +230,14 @@ object FetchHandler {
 
     fun retrieveGenres(resolver: ContentResolver): ArrayList<MutableMap<String, Any?>> {
         val memberProjection = arrayOf(MediaStore.Audio.Genres.Members._ID)
+        val contentUrl = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            MediaStore.Audio.Genres.getContentUri(MediaStore.VOLUME_EXTERNAL)
+        } else {
+            MediaStore.Audio.Genres.EXTERNAL_CONTENT_URI
+        }
         return executeQuery(
             resolver,
-            MediaStore.Audio.Genres.EXTERNAL_CONTENT_URI,
+            contentUrl,
             MediaStore.Audio.Genres.NAME + " IS NOT NULL",
             mapOf(
                 MediaStore.Audio.Genres._ID to Pair("id") { cursor, index -> cursor.getInt(index) },


### PR DESCRIPTION
This is an attempt to fix the `java.lang.IllegalArgumentException: Volume external_primary not found` that we see on Crashlytics ([[1]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/612523973ce5c75b4258b250bbace33e?time=last-ninety-days&sessionEventKey=6679036E025E0001146F2EE12BAD35D5_1962382447577852706), [[2]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/a59942b3b39bda908c06adaaf545b72d?time=last-ninety-days&sessionEventKey=6679036E025E0001146F2EE12BAD35D5_1962382447577852708), [[3]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/b9f977f35adceab9fa61f6d2ff5dc366?time=last-ninety-days&sessionEventKey=6679036E025E0001146F2EE12BAD35D5_1962382447577852707)).

I can't replicate the problem in an emulator, but I verified that we still query all media on the phone with these changes.

The is not much to find about this problem, except one [StackOverflow post](https://stackoverflow.com/questions/63111091/java-lang-illegalargumentexception-volume-external-primary-not-found-in-android).

Google is still using the constant in their [generic example](https://developer.android.com/training/data-storage/shared/media#media_store)

![Generic example](https://github.com/user-attachments/assets/0f9399e2-c39e-49a3-8efe-fdf2fcfeb707)

But they use the `getContentUri` in the [query the media collection example](https://developer.android.com/training/data-storage/shared/media#query-collection):

![Query media collection example](https://github.com/user-attachments/assets/b8e2bfa4-a5b8-4dca-a2bd-4ffd69bdaac7)
