### PR TITLE
Remove tuple dependency

### DIFF
--- a/lib/widgets/content_list_view/persistent_queue_tile.dart
+++ b/lib/widgets/content_list_view/persistent_queue_tile.dart
@@ -3,7 +3,6 @@ import 'dart:math' as math;
 import 'package:boxy/boxy.dart';
 import 'package:flutter/material.dart';
 import 'package:sweyer/sweyer.dart';
-import 'package:tuple/tuple.dart';
 
 const double _tileVerticalPadding = 8.0;
 const double kPersistentQueueTileHorizontalPadding = 16.0;
@@ -46,7 +45,7 @@ double _calculatePersistentQueueTileHeight(ContentType contentType, BuildContext
     textScaleFactor,
     _titleTheme(theme)?.fontSize,
     _subtitleTheme(contentType, theme)?.fontSize,
-    Tuple2(contentType, context),
+    (contentType, context),
   );
 }
 
@@ -55,11 +54,11 @@ final _calculatePersistentQueueTileHeightMemo = imemo3plus1(
     double a1,
     double? a2,
     double? a3,
-    Tuple2<ContentType, BuildContext> a4,
+    (ContentType, BuildContext) a4,
   ) =>
       math.max(
         kPersistentQueueTileArtSize,
-        _kPresisentQueueTileTextHeight(a4.item1, a4.item2),
+        _kPresisentQueueTileTextHeight(a4.$1, a4.$2),
       ) +
       _tileVerticalPadding * 2,
 );
@@ -76,7 +75,7 @@ double _calculatePersistentQueueGridTileHeight(
     gridArtSize,
     _titleTheme(theme)?.fontSize,
     _subtitleTheme(contentType, theme)?.fontSize,
-    Tuple2(contentType, context),
+    (contentType, context),
   );
 }
 
@@ -86,9 +85,9 @@ final _calculatePersistentQueueGridTileHeightMemo = imemo4plus1(
     double gridArtSize,
     double? a3,
     double? a4,
-    Tuple2<ContentType, BuildContext> a5,
+    (ContentType, BuildContext) a5,
   ) =>
-      gridArtSize + _kPresisentQueueTileTextHeight(a5.item1, a5.item2) + _tileVerticalPadding * 2,
+      gridArtSize + _kPresisentQueueTileTextHeight(a5.$1, a5.$2) + _tileVerticalPadding * 2,
 );
 
 /// The height of the title and subtitle part of the [PersistentQueueTile].

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1309,14 +1309,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
-  tuple:
-    dependency: "direct main"
-    description:
-      name: tuple
-      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,6 @@ dependencies:
   freezed_annotation: ^2.2.0
   json_annotation: ^4.7.0
   memoize: ^3.0.0
-  tuple: ^2.0.1
 
   # quick_actions: ^0.6.0 # TODO: quick actions are blocked on https://github.com/ryanheise/audio_service/issues/671
 

--- a/test/routes/selection_route_test.dart
+++ b/test/routes/selection_route_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:tuple/tuple.dart';
 
 import '../test.dart';
 
@@ -278,14 +277,12 @@ void main() {
     final playlist1 = playlistWith(id: 1, songIds: [song1.id]);
     final playlist2 = playlistWith(id: 2, songIds: [song2.id]);
 
-    for (var tabAndContentType in [
-      const Tuple2('tracks', ContentType.song),
-      const Tuple2('album', ContentType.album),
-      const Tuple2('playlists', ContentType.playlist),
-      const Tuple2('artists', ContentType.artist),
+    for (final (tabName, contentType) in [
+      ('tracks', ContentType.song),
+      ('album', ContentType.album),
+      ('playlists', ContentType.playlist),
+      ('artists', ContentType.artist),
     ]) {
-      final tabName = tabAndContentType.item1;
-      final contentType = tabAndContentType.item2;
       testWidgets('allows selecting all and deselecting all on the $tabName tab', (WidgetTester tester) async {
         await setUpAppTest(() {
           FakeSweyerPluginPlatform.instance.songs = [song0, song1, song2];


### PR DESCRIPTION
*Depends on #130.*

With the update of Flutter came an update to Dart 3 wich introduces records (aka tuples), so we don't need the dependency anymore.