### PR TITLE
Don't error when a playlist has no modification date

### DIFF
--- a/lib/logic/models/playlist.dart
+++ b/lib/logic/models/playlist.dart
@@ -108,11 +108,12 @@ class Playlist extends PersistentQueue with DuplicatingSongOriginMixin implement
   }
 
   factory Playlist.fromMap(Map<String, dynamic> map) {
+    int dateAdded = map['dateAdded'] as int;
     return Playlist(
       id: map['id'] as int,
       filesystemPath: map['filesystemPath'] as String,
-      dateAdded: map['dateAdded'] as int,
-      dateModified: map['dateModified'] as int,
+      dateAdded: dateAdded,
+      dateModified: map['dateModified'] as int? ?? dateAdded,
       name: map['name'] as String,
       songIds: (map['songIds'] as List).cast<int>().toList(),
     );


### PR DESCRIPTION
Use the creation date if no modification date is present.

This fixes the following error observed on Crashlytics ([[1]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/d1875b57ccacd08b9b36a5fe2c6ec794?time=last-ninety-days&sessionEventKey=6692686C012B000167ECB8B434C003B9_1969530388087311267), maybe also [[2]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/f4716b11a5257ee44c8995acc25e7e3d?time=last-ninety-days&sessionEventKey=666CE8C8017A00013B5A7B3F3CA8932E_1958977251308973358), [[3]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/afe37557daeeb231ef7c67a9eeb42fe2?time=last-ninety-days&sessionEventKey=666B961402F700012F63341D998A5D1E_1958603032273598029), [[4]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/d1875b57ccacd08b9b36a5fe2c6ec794?time=last-ninety-days&sessionEventKey=6692686C012B000167ECB8B434C003B9_1969530388087311267), [[5]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/0d41c07fcaeb78d1407e0740dc8939f8?time=last-ninety-days&sessionEventKey=666B937B01A600012556341D998A5D1E_1958600174818209212), [[6]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/224db63094e87aae6fbb1a93ff70ba58?time=last-ninety-days&sessionEventKey=666AAC1E008100010DDC341D998A5D1E_1958345789359021250), [[7]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/2b1040174f296dc0655e72b5bf3c099e?time=last-ninety-days&sessionEventKey=666AAC0F00FB00010CC8341D998A5D1E_1958345724524178745), [[8]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/54500c47797583c5a263994fd07b4b4d?time=last-ninety-days&sessionEventKey=666A340C00F6000178AED7AA2F167BAC_1958213775026462281), [[9]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/5636a310be945c73491eb9a354be9f92?time=last-ninety-days&sessionEventKey=666C084101620001512C341D998A5D1E_1958728575435466596), [[10]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/59d7b87292da92f00716bfe9a28e0063?time=last-ninety-days&sessionEventKey=666DD01C01B2000136FAF29124B61F42_1959231741799819699), [[11]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/627f13750812912de33b88356dcb8887?time=last-ninety-days&sessionEventKey=666B95D6013F00012D7A341D998A5D1E_1958602763461339603), [[12]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/683ba9552fc366ac9d32bb0578293226?time=last-ninety-days&sessionEventKey=666B974E037C000134FB341D998A5D1E_1958604385936509382), [[13]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/8d2acb5c475fc25a6d345fdb48cc262c?time=last-ninety-days&sessionEventKey=666B9193036F00011CFA341D998A5D1E_1958598082439848041), [[14]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/9e030048dfc71dd8574b79f8e6d284c2?time=last-ninety-days&sessionEventKey=666AABC4004C0001085F341D998A5D1E_1958345402886639109), [[15]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/aa8b54424719fd062e2a690442bd7807?time=last-ninety-days&sessionEventKey=666C0805021D00013BD8341D998A5D1E_1958728312270223649)):

<details><summary>Stacktrace</summary> 

```
          Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: type 'Null' is not a subtype of type 'int' in type cast
       at new Playlist.fromMap(playlist.dart:115)
       at ListIterable.toList(dart:_internal)
       at ContentControl.refetch(content.dart:409)
       at Future.wait.<fn>(dart:async)
       at ContentControl.refetchSongsAndPlaylists(content.dart:682)
       at ContentControl.createPlaylist(content.dart:739)
       at ShowFunctions.showCreatePlaylist.submit(show_functions.dart:64)
```
</details> 