### PR TITLE
Fix error when changing the app color before granting permissions

### DIFF
--- a/lib/logic/player/playback.dart
+++ b/lib/logic/player/playback.dart
@@ -12,12 +12,6 @@ class PlaybackControl extends Control {
   static PlaybackControl instance = PlaybackControl();
 
   @override
-  void init() {
-    super.init();
-    _songSubject = BehaviorSubject();
-  }
-
-  @override
   void dispose() {
     if (!disposed.value) {
       _songSubject.close();
@@ -30,7 +24,7 @@ class PlaybackControl extends Control {
 
   /// A stream of changes on [currentSong].
   Stream<Song> get onSongChange => _songSubject.stream;
-  late BehaviorSubject<Song> _songSubject;
+  final BehaviorSubject<Song> _songSubject = BehaviorSubject();
 
   /// The current playing song.
   Song get currentSong {

--- a/lib/logic/player/playback.dart
+++ b/lib/logic/player/playback.dart
@@ -12,6 +12,14 @@ class PlaybackControl extends Control {
   static PlaybackControl instance = PlaybackControl();
 
   @override
+  void init() {
+    super.init();
+    if (_songSubject.isClosed) {
+      _songSubject = BehaviorSubject();
+    }
+  }
+
+  @override
   void dispose() {
     if (!disposed.value) {
       _songSubject.close();
@@ -24,7 +32,7 @@ class PlaybackControl extends Control {
 
   /// A stream of changes on [currentSong].
   Stream<Song> get onSongChange => _songSubject.stream;
-  final BehaviorSubject<Song> _songSubject = BehaviorSubject();
+  BehaviorSubject<Song> _songSubject = BehaviorSubject();
 
   /// The current playing song.
   Song get currentSong {

--- a/lib/routes/settings_route/theme_settings.dart
+++ b/lib/routes/settings_route/theme_settings.dart
@@ -108,7 +108,7 @@ class _ThemeSettingsRouteState extends State<ThemeSettingsRoute> with SingleTick
                 padding: const EdgeInsets.symmetric(horizontal: 12.0),
                 scrollDirection: Axis.horizontal,
                 itemCount: colors.length,
-                itemBuilder: (context, idx) => _ColorItem(
+                itemBuilder: (context, idx) => ColorItem(
                     color: colors[idx],
                     active: colors[idx] == primaryColor,
                     onTap: () {
@@ -149,8 +149,9 @@ class _ThemeSettingsRouteState extends State<ThemeSettingsRoute> with SingleTick
   }
 }
 
-class _ColorItem extends StatefulWidget {
-  const _ColorItem({
+@visibleForTesting
+class ColorItem extends StatefulWidget {
+  const ColorItem({
     Key? key,
     required this.color,
     required this.onTap,
@@ -165,7 +166,7 @@ class _ColorItem extends StatefulWidget {
   _ColorItemState createState() => _ColorItemState();
 }
 
-class _ColorItemState extends State<_ColorItem> with SingleTickerProviderStateMixin {
+class _ColorItemState extends State<ColorItem> with SingleTickerProviderStateMixin {
   late AnimationController controller;
 
   @override
@@ -181,7 +182,7 @@ class _ColorItemState extends State<_ColorItem> with SingleTickerProviderStateMi
   }
 
   @override
-  void didUpdateWidget(covariant _ColorItem oldWidget) {
+  void didUpdateWidget(covariant ColorItem oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.active != widget.active) {
       if (widget.active) {

--- a/test/routes/home_route_test.dart
+++ b/test/routes/home_route_test.dart
@@ -4,6 +4,7 @@ import 'package:back_button_interceptor/back_button_interceptor.dart';
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:sweyer/constants.dart';
+import 'package:sweyer/routes/settings_route/theme_settings.dart';
 
 import '../observer/observer.dart';
 import '../test.dart';
@@ -221,6 +222,73 @@ void main() {
             tester.getTopLeft(find.descendant(of: find.byType(PlayerRoute), matching: find.byType(TrackPanel))).dy;
         expect(tabBarTop, trackPanelTop);
       });
+    });
+  });
+
+  testWidgets('Allows changing settings when uninitialized and no permissions were granted',
+      (WidgetTester tester) async {
+    await setUpAppTest(() {
+      PermissionsChannelObserver permissionsObserver = PermissionsChannelObserver(tester.binding);
+      permissionsObserver.setPermission(Permission.storage, PermissionStatus.denied);
+      permissionsObserver.setPermission(Permission.audio, PermissionStatus.denied);
+    });
+    await tester.runAppTest(() async {
+      // Go to the settings
+      await tester.tap(find.byType(SettingsButton));
+      await tester.pumpAndSettle();
+
+      // Go to the general settings page
+      await tester.tap(find.text(staticl10n.general));
+      await tester.pumpAndSettle();
+
+      // Toggle all switch settings
+      for (var setting in [
+        staticl10n.confirmExitingWithBackButtonSetting,
+        staticl10n.useMediaStoreForFavoriteSongsSetting,
+      ]) {
+        // Toggle switch
+        await tester.tap(find.text(setting));
+        await tester.pumpAndSettle();
+
+        // Toggle switch back
+        await tester.tap(find.text(setting));
+        await tester.pumpAndSettle();
+      }
+
+      // Go to the theme settings page
+      await BackButtonInterceptor.popRoute();
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(staticl10n.theme));
+      await tester.pumpAndSettle();
+
+      // Open the player theme setting dialog and toggle the setting
+      await tester.tap(find.text(staticl10n.playerInterfaceColorStyle));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(staticl10n.playerInterfaceColorStyleThemeBackgroundColor));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(staticl10n.playerInterfaceColorStyle));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(staticl10n.playerInterfaceColorStyleArtColor));
+      await tester.pumpAndSettle();
+
+      // Toggle all switch settings
+      for (var setting in [
+        staticl10n.settingLightMode,
+      ]) {
+        // Toggle switch
+        await tester.tap(find.text(setting));
+        await tester.pumpAndSettle();
+
+        // Toggle switch back
+        await tester.tap(find.text(setting));
+        await tester.pumpAndSettle();
+      }
+
+      // Toggle color choices
+      await tester.tap(find.byType(ColorItem).last);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(ColorItem).first);
+      await tester.pumpAndSettle();
     });
   });
 }


### PR DESCRIPTION
The user can change settings before granting permissions to the media. In this state we don't fully initialize the audio player, which caused a crash that was captured by Crashlytics ([[1]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/e1062f968ba29597bf7c151f0113590f?time=last-ninety-days&sessionEventKey=66806057037500011F3F73AEE12731E5_1964456254375290935), maybe also [[2]](https://console.firebase.google.com/u/2/project/sweyer-def42/crashlytics/app/android:com.nt4f04und.sweyer/issues/2c370cc8ce03b3ee6f49bd7e6fc8a846?time=last-ninety-days&sessionEventKey=666A34A0023500012288FB1F4F235DDF_1958214607951902040)).

<details><summary>Stacktrace</summary>

```
          Non-fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: LateInitializationError: Field '_vBf@1817350162' has not been initialized.. Error thrown Instance of 'ZD'.
#00 pc 0x44db6f com.nt4f04und.sweyer (MusicPlayer.updateServiceMediaItem [music_player.dart:638]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#01 pc 0x44ceab com.nt4f04und.sweyer (ThemeControl.changePrimaryColor [theme.dart:133]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#02 pc 0x44cd63 com.nt4f04und.sweyer (_ThemeSettingsRouteState._handleColorTap [theme_settings.dart:72]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#03 pc 0x44cc7b com.nt4f04und.sweyer (_ThemeSettingsRouteState.build.<anonymous closure>.<anonymous closure> [theme_settings.dart:115]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#04 pc 0x44e1c7 com.nt4f04und.sweyer (_ColorItemState._handleTap [theme_settings.dart:202]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#05 pc 0x44e167 com.nt4f04und.sweyer (_ColorItemState._handleTap [theme_settings.dart:201]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#06 pc 0x6f7f93 com.nt4f04und.sweyer (GestureRecognizer.invokeCallback [recognizer.dart:253]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#07 pc 0x6109fb com.nt4f04und.sweyer (TapGestureRecognizer.handleTapUp [tap.dart:627]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#08 pc 0x5263fb com.nt4f04und.sweyer (BaseTapGestureRecognizer._checkUp [tap.dart:306]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#09 pc 0x598887 com.nt4f04und.sweyer (BaseTapGestureRecognizer.acceptGesture [tap.dart:276]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#10 pc 0x2b0773 com.nt4f04und.sweyer (GestureArenaManager.sweep [arena.dart:163]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#11 pc 0x2b05e3 com.nt4f04und.sweyer (GestureBinding.handleEvent [binding.dart:464]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#12 pc 0x6b7067 com.nt4f04und.sweyer (GestureBinding.dispatchEvent [binding.dart:440]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#13 pc 0x32fe87 com.nt4f04und.sweyer (RendererBinding.dispatchEvent [binding.dart:336]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#14 pc 0x32fdcf com.nt4f04und.sweyer (GestureBinding._handlePointerEventImmediately [binding.dart:395]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#15 pc 0x32f87f com.nt4f04und.sweyer (GestureBinding._flushPointerEventQueue [binding.dart:357]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#16 pc 0x40a293 com.nt4f04und.sweyer (GestureBinding._handlePointerDataPacket [binding.dart:295]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#17 pc 0x40a197 com.nt4f04und.sweyer (GestureBinding._handlePointerDataPacket [binding.dart:290]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#18 pc 0x1c8c1f com.nt4f04und.sweyer (_invoke1 [hooks.dart:164]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#19 pc 0x1c950f com.nt4f04und.sweyer (PlatformDispatcher._dispatchPointerDataPacket [platform_dispatcher.dart:361]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
#20 pc 0x1c948b com.nt4f04und.sweyer (_dispatchPointerDataPacket [hooks.dart:91]) (BuildId: bca64abf9d3a446731bb8f1cafebb215)
```
</details>

This fixes the problem and adds a test for changing all settings before granting permissions.