### PR TITLE
If the media store favourite state is unknown, treat it as no favourite

### DIFF
--- a/lib/logic/models/song.dart
+++ b/lib/logic/models/song.dart
@@ -45,11 +45,11 @@ class Song extends Content implements PlatformSong {
 
   /// Whether the content was marked as favorite in MediaStore.
   ///
-  /// Only available starting from Android R (30), below this is always `null`.
+  /// Only available starting from Android R (30), below this is always `false`.
   ///
   /// See also:
   ///  * [isFavorite] getter
-  final bool? isFavoriteInMediaStore;
+  final bool isFavoriteInMediaStore;
 
   /// Generation number at which metadata for this media item was first inserted.
   ///
@@ -166,7 +166,7 @@ class Song extends Content implements PlatformSong {
       duration: map['duration'] as int,
       size: map['size'] as int?,
       filesystemPath: map['filesystemPath'] as String?,
-      isFavoriteInMediaStore: map['isFavoriteInMediaStore'] as bool?,
+      isFavoriteInMediaStore: map['isFavoriteInMediaStore'] as bool? ?? false,
       generationAdded: map['generationAdded'] as int?,
       generationModified: map['generationModified'] as int?,
     );
@@ -223,7 +223,7 @@ abstract class SongCopyWith {
     int duration,
     int? size,
     String? filesystemPath,
-    bool? isFavoriteInMediaStore,
+    bool isFavoriteInMediaStore,
     int? generationAdded,
     int? generationModified,
     int? duplicationIndex,
@@ -279,7 +279,7 @@ class _SongCopyWith extends SongCopyWith {
       size: size == _undefined ? value.size : size as int?,
       filesystemPath: filesystemPath == _undefined ? value.filesystemPath : filesystemPath as String?,
       isFavoriteInMediaStore:
-          isFavoriteInMediaStore == _undefined ? value.isFavoriteInMediaStore : isFavoriteInMediaStore as bool?,
+          isFavoriteInMediaStore == _undefined ? value.isFavoriteInMediaStore : isFavoriteInMediaStore as bool,
       generationAdded: generationAdded == _undefined ? value.generationAdded : generationAdded as int?,
       generationModified: generationModified == _undefined ? value.generationModified : generationModified as int?,
       duplicationIndex: duplicationIndex == _undefined ? value.duplicationIndex : duplicationIndex as int?,

--- a/lib/logic/player/favorites.dart
+++ b/lib/logic/player/favorites.dart
@@ -54,7 +54,7 @@ class FavoritesControl with Control {
     final Set<int> favoriteSet = {};
     if (_useMediaStoreFavorites(contentType)) {
       for (final song in ContentControl.instance.state.allSongs.songs) {
-        if (song.isFavoriteInMediaStore!) {
+        if (song.isFavoriteInMediaStore ?? false) {
           favoriteSet.add(song.sourceId);
         }
       }
@@ -209,9 +209,9 @@ class FavoritesControl with Control {
         await ContentControl.instance.refetch(ContentType.song);
         final favoriteSet = _favoriteSetsMap.get(ContentType.song);
         for (final song in ContentControl.instance.state.allSongs.songs) {
-          if (song.isFavoriteInMediaStore! && !favoriteSet.contains(song.id)) {
+          if ((song.isFavoriteInMediaStore ?? false) && !favoriteSet.contains(song.id)) {
             favoriteSet.add(song.id);
-          } else if (!song.isFavoriteInMediaStore! && favoriteSet.contains(song.id)) {
+          } else if (!(song.isFavoriteInMediaStore ?? false) && favoriteSet.contains(song.id)) {
             favoriteSet.remove(song.id);
           }
         }

--- a/lib/logic/player/favorites.dart
+++ b/lib/logic/player/favorites.dart
@@ -54,7 +54,7 @@ class FavoritesControl with Control {
     final Set<int> favoriteSet = {};
     if (_useMediaStoreFavorites(contentType)) {
       for (final song in ContentControl.instance.state.allSongs.songs) {
-        if (song.isFavoriteInMediaStore ?? false) {
+        if (song.isFavoriteInMediaStore) {
           favoriteSet.add(song.sourceId);
         }
       }
@@ -209,9 +209,9 @@ class FavoritesControl with Control {
         await ContentControl.instance.refetch(ContentType.song);
         final favoriteSet = _favoriteSetsMap.get(ContentType.song);
         for (final song in ContentControl.instance.state.allSongs.songs) {
-          if ((song.isFavoriteInMediaStore ?? false) && !favoriteSet.contains(song.id)) {
+          if (song.isFavoriteInMediaStore && !favoriteSet.contains(song.id)) {
             favoriteSet.add(song.id);
-          } else if (!(song.isFavoriteInMediaStore ?? false) && favoriteSet.contains(song.id)) {
+          } else if (!song.isFavoriteInMediaStore && favoriteSet.contains(song.id)) {
             favoriteSet.remove(song.id);
           }
         }


### PR DESCRIPTION
While adding tests to work towards #127, I noticed that we would crash if `isFavoriteInMediaStore` was `null`. We haven't seen this on Crashlytics yet, but this can definitely happen on older (pre `R`, API level `30`) devices.