### PR TITLE
Improve content scanning

### DIFF
--- a/lib/logic/models/album.dart
+++ b/lib/logic/models/album.dart
@@ -1,5 +1,6 @@
 import 'package:audio_service/audio_service.dart';
 import 'package:collection/collection.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:sweyer/sweyer.dart';
 import 'package:sweyer_plugin/sweyer_plugin.dart';
 
@@ -87,17 +88,27 @@ class Album extends PersistentQueue implements PlatformAlbum {
     );
   }
 
-  factory Album.fromMap(Map<String, dynamic> map) {
-    return Album(
-      id: map['id'] as int,
-      album: map['album'] as String,
-      albumArt: map['albumArt'] as String?,
-      artist: map['artist'] as String,
-      artistId: map['artistId'] as int?,
-      firstYear: map['firstYear'] as int?,
-      lastYear: map['lastYear'] as int?,
-      numberOfSongs: map['numberOfSongs'] as int? ?? 0,
-    );
+  static Album? fromMap(Map<String, dynamic> map) {
+    try {
+      return Album(
+        id: map['id'] as int,
+        album: map['album'] as String,
+        albumArt: map['albumArt'] as String?,
+        artist: map['artist'] as String,
+        artistId: map['artistId'] as int?,
+        firstYear: map['firstYear'] as int?,
+        lastYear: map['lastYear'] as int?,
+        numberOfSongs: map['numberOfSongs'] as int? ?? 0,
+      );
+    } on TypeError catch (error, stack) {
+      FirebaseCrashlytics.instance.recordError(
+        error,
+        stack,
+        reason: 'trying to parse an album',
+        fatal: false,
+      );
+      return null;
+    }
   }
 
   @override
@@ -125,7 +136,7 @@ abstract class AlbumCopyWith {
   Album call({
     int id,
     String album,
-    String albumArt,
+    String? albumArt,
     String artist,
     int? artistId,
     int? firstYear,
@@ -148,7 +159,7 @@ class _AlbumCopyWith extends AlbumCopyWith {
   Album call({
     Object id = _undefined,
     Object album = _undefined,
-    Object albumArt = _undefined,
+    Object? albumArt = _undefined,
     Object artist = _undefined,
     Object? artistId = _undefined,
     Object? firstYear = _undefined,
@@ -158,7 +169,7 @@ class _AlbumCopyWith extends AlbumCopyWith {
     return Album(
       id: id == _undefined ? value.id : id as int,
       album: album == _undefined ? value.album : album as String,
-      albumArt: albumArt == _undefined ? value.albumArt : albumArt as String,
+      albumArt: albumArt == _undefined ? value.albumArt : albumArt as String?,
       artist: artist == _undefined ? value.artist : artist as String,
       artistId: artistId == _undefined ? value.artistId : artistId as int?,
       firstYear: firstYear == _undefined ? value.firstYear : firstYear as int?,

--- a/lib/logic/models/artist.dart
+++ b/lib/logic/models/artist.dart
@@ -1,4 +1,5 @@
 import 'package:audio_service/audio_service.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:sweyer/sweyer.dart';
 import 'package:sweyer_plugin/sweyer_plugin.dart';
 
@@ -76,13 +77,23 @@ class Artist extends SongOrigin implements PlatformArtist {
     );
   }
 
-  factory Artist.fromMap(Map<String, dynamic> map) {
-    return Artist(
-      id: map['id'] as int,
-      artist: map['artist'] as String,
-      numberOfAlbums: map['numberOfAlbums'] as int,
-      numberOfTracks: map['numberOfTracks'] as int,
-    );
+  static Artist? fromMap(Map<String, dynamic> map) {
+    try {
+      return Artist(
+        id: map['id'] as int,
+        artist: map['artist'] as String,
+        numberOfAlbums: map['numberOfAlbums'] as int,
+        numberOfTracks: map['numberOfTracks'] as int,
+      );
+    } on TypeError catch (error, stack) {
+      FirebaseCrashlytics.instance.recordError(
+        error,
+        stack,
+        reason: 'trying to parse an artist',
+        fatal: false,
+      );
+      return null;
+    }
   }
 
   @override

--- a/lib/logic/models/content.dart
+++ b/lib/logic/models/content.dart
@@ -50,7 +50,7 @@ abstract class Content with EquatableMixin {
   /// An icon for this content type.
   IconData get icon => type.icon;
 
-  /// Whether the content was marked as favorite by user.
+  /// Whether the content was marked as favorite by the user.
   bool get isFavorite => FavoritesControl.instance.isFavorite(this);
 }
 

--- a/lib/logic/models/genre.dart
+++ b/lib/logic/models/genre.dart
@@ -1,4 +1,5 @@
 import 'package:audio_service/audio_service.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:sweyer/sweyer.dart';
 import 'package:sweyer_plugin/sweyer_plugin.dart';
 
@@ -26,12 +27,22 @@ class Genre extends Content implements PlatformGenre {
   @override
   GenreCopyWith get copyWith => _GenreCopyWith(this);
 
-  factory Genre.fromMap(Map<String, dynamic> map) {
-    return Genre(
-      id: map['id'] as int,
-      name: map['name'] as String,
-      songIds: (map['songIds'] as List?)?.cast<int>() ?? [],
-    );
+  static Genre? fromMap(Map<String, dynamic> map) {
+    try {
+      return Genre(
+        id: map['id'] as int,
+        name: map['name'] as String,
+        songIds: (map['songIds'] as List?)?.cast<int>() ?? [],
+      );
+    } on TypeError catch (error, stack) {
+      FirebaseCrashlytics.instance.recordError(
+        error,
+        stack,
+        reason: 'trying to parse a genre',
+        fatal: false,
+      );
+      return null;
+    }
   }
 
   @override

--- a/lib/logic/models/playlist.dart
+++ b/lib/logic/models/playlist.dart
@@ -1,4 +1,5 @@
 import 'package:audio_service/audio_service.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:sweyer/sweyer.dart';
 import 'package:sweyer_plugin/sweyer_plugin.dart';
 
@@ -107,15 +108,25 @@ class Playlist extends PersistentQueue with DuplicatingSongOriginMixin implement
     );
   }
 
-  factory Playlist.fromMap(Map<String, dynamic> map) {
-    return Playlist(
-      id: map['id'] as int,
-      filesystemPath: map['filesystemPath'] as String?,
-      dateAdded: map['dateAdded'] as int,
-      dateModified: map['dateModified'] as int?,
-      name: map['name'] as String,
-      songIds: (map['songIds'] as List?)?.cast<int>().toList() ?? [],
-    );
+  static Playlist? fromMap(Map<String, dynamic> map) {
+    try {
+      return Playlist(
+        id: map['id'] as int,
+        filesystemPath: map['filesystemPath'] as String?,
+        dateAdded: map['dateAdded'] as int,
+        dateModified: map['dateModified'] as int?,
+        name: map['name'] as String,
+        songIds: (map['songIds'] as List?)?.cast<int>().toList() ?? [],
+      );
+    } on TypeError catch (error, stack) {
+      FirebaseCrashlytics.instance.recordError(
+        error,
+        stack,
+        reason: 'trying to parse a playlist',
+        fatal: false,
+      );
+      return null;
+    }
   }
 
   @override

--- a/lib/logic/models/song.dart
+++ b/lib/logic/models/song.dart
@@ -153,7 +153,8 @@ class Song extends Content implements PlatformSong {
 
   static Song? fromMap(Map<String, dynamic> map) {
     try {
-      final dateAdded = map['dateAdded'] as int;return Song(
+      final dateAdded = map['dateAdded'] as int;
+      return Song(
         id: map['id'] as int,
         album: map['album'] as String?,
         albumId: map['albumId'] as int?,

--- a/lib/logic/models/song.dart
+++ b/lib/logic/models/song.dart
@@ -1,4 +1,5 @@
 import 'package:audio_service/audio_service.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:sweyer/sweyer.dart';
 import 'package:sweyer_plugin/sweyer_plugin.dart';
 
@@ -23,6 +24,7 @@ class Song extends Content implements PlatformSong {
   final int? albumId;
   final String artist;
   final int artistId;
+
   // TODO: Voodoo shenanigans on android versions with this (and other places where i can)
   final String? genre;
   final int? genreId;
@@ -149,27 +151,36 @@ class Song extends Content implements PlatformSong {
     );
   }
 
-  factory Song.fromMap(Map<String, dynamic> map) {
-    final dateAdded = map['dateAdded'] as int;
-    return Song(
-      id: map['id'] as int,
-      album: map['album'] as String?,
-      albumId: map['albumId'] as int?,
-      artist: map['artist'] as String,
-      artistId: map['artistId'] as int,
-      genre: map['genre'] as String?,
-      genreId: map['genreId'] as int?,
-      title: map['title'] as String,
-      track: map['track'] as String?,
-      dateAdded: dateAdded,
-      dateModified: map['dateModified'] as int? ?? dateAdded,
-      duration: map['duration'] as int,
-      size: map['size'] as int?,
-      filesystemPath: map['filesystemPath'] as String?,
-      isFavoriteInMediaStore: map['isFavoriteInMediaStore'] as bool? ?? false,
-      generationAdded: map['generationAdded'] as int?,
-      generationModified: map['generationModified'] as int?,
-    );
+  static Song? fromMap(Map<String, dynamic> map) {
+    try {
+      final dateAdded = map['dateAdded'] as int;return Song(
+        id: map['id'] as int,
+        album: map['album'] as String?,
+        albumId: map['albumId'] as int?,
+        artist: map['artist'] as String,
+        artistId: map['artistId'] as int,
+        genre: map['genre'] as String?,
+        genreId: map['genreId'] as int?,
+        title: map['title'] as String,
+        track: map['track'] as String?,
+        dateAdded: dateAdded,
+        dateModified: map['dateModified'] as int? ?? dateAdded,
+        duration: map['duration'] as int,
+        size: map['size'] as int?,
+        filesystemPath: map['filesystemPath'] as String?,
+        isFavoriteInMediaStore: map['isFavoriteInMediaStore'] as bool? ?? false,
+        generationAdded: map['generationAdded'] as int?,
+        generationModified: map['generationModified'] as int?,
+      );
+    } on TypeError catch (error, stack) {
+      FirebaseCrashlytics.instance.recordError(
+        error,
+        stack,
+        reason: 'trying to parse a song',
+        fatal: false,
+      );
+      return null;
+    }
   }
 
   @override

--- a/sweyer_plugin/lib/sweyer_plugin.dart
+++ b/sweyer_plugin/lib/sweyer_plugin.dart
@@ -17,7 +17,10 @@ abstract class PlatformSong {
 }
 
 /// An album from the native platform.
-abstract class PlatformAlbum {}
+abstract class PlatformAlbum {
+  /// The id of this album in the native platform.
+  int get id;
+}
 
 /// An artist from the native platform.
 abstract class PlatformArtist {}
@@ -46,7 +49,21 @@ class CancellationSignal {
 }
 
 /// A factory to load an implementation from the raw data describing a platform item.
-typedef DataFactory<T> = T Function(Map<String, dynamic> data);
+typedef DataFactory<T> = T? Function(Map<String, dynamic> data);
+
+// TODO: Remove this extension once we switch to Dart3.
+extension NullableIterableExtensions<T extends Object> on Iterable<T?> {
+  /// The non-`null` elements of this iterable.
+  ///
+  /// The same elements as this iterable, except that `null` values are omitted.
+  Iterable<T> get nonNulls sync* {
+    for (final element in this) {
+      if (element != null) {
+        yield element;
+      }
+    }
+  }
+}
 
 class SweyerPlugin {
   static const instance = SweyerPlugin();
@@ -73,25 +90,21 @@ class SweyerPlugin {
   Future<void> fixAlbumArt(int albumId) async => await SweyerPluginPlatform.instance.fixAlbumArt(albumId);
 
   Future<Iterable<T>> retrieveSongs<T extends PlatformSong>(DataFactory<T> factory) async =>
-      (await SweyerPluginPlatform.instance.retrieveSongs()).map(factory);
+      (await SweyerPluginPlatform.instance.retrieveSongs()).map(factory).nonNulls;
 
-  Future<Map<int, T>> retrieveAlbums<T extends PlatformAlbum>(DataFactory<T> factory) async {
-    final maps = await SweyerPluginPlatform.instance.retrieveAlbums();
-    final Map<int, T> albums = {};
-    for (final map in maps) {
-      albums[map['id'] as int] = factory(map);
-    }
-    return albums;
-  }
+  Future<Map<int, T>> retrieveAlbums<T extends PlatformAlbum>(DataFactory<T> factory) async => Map.fromIterable(
+        (await SweyerPluginPlatform.instance.retrieveAlbums()).map(factory).nonNulls,
+        key: (album) => album.id,
+      );
 
   Future<Iterable<T>> retrievePlaylists<T extends PlatformPlaylist>(DataFactory<T> factory) async =>
-      (await SweyerPluginPlatform.instance.retrievePlaylists()).map(factory);
+      (await SweyerPluginPlatform.instance.retrievePlaylists()).map(factory).nonNulls;
 
   Future<Iterable<T>> retrieveArtists<T extends PlatformArtist>(DataFactory<T> factory) async =>
-      (await SweyerPluginPlatform.instance.retrieveArtists()).map(factory);
+      (await SweyerPluginPlatform.instance.retrieveArtists()).map(factory).nonNulls;
 
   Future<Iterable<T>> retrieveGenres<T extends PlatformGenre>(DataFactory<T> factory) async =>
-      (await SweyerPluginPlatform.instance.retrieveGenres()).map(factory);
+      (await SweyerPluginPlatform.instance.retrieveGenres()).map(factory).nonNulls;
 
   /// Sets the songs favorite flag to [value].
   ///

--- a/sweyer_plugin/lib/sweyer_plugin.dart
+++ b/sweyer_plugin/lib/sweyer_plugin.dart
@@ -51,20 +51,6 @@ class CancellationSignal {
 /// A factory to load an implementation from the raw data describing a platform item.
 typedef DataFactory<T> = T? Function(Map<String, dynamic> data);
 
-// TODO: Remove this extension once we switch to Dart3.
-extension NullableIterableExtensions<T extends Object> on Iterable<T?> {
-  /// The non-`null` elements of this iterable.
-  ///
-  /// The same elements as this iterable, except that `null` values are omitted.
-  Iterable<T> get nonNulls sync* {
-    for (final element in this) {
-      if (element != null) {
-        yield element;
-      }
-    }
-  }
-}
-
 class SweyerPlugin {
   static const instance = SweyerPlugin();
 

--- a/test/fakes/fake_firebase.dart
+++ b/test/fakes/fake_firebase.dart
@@ -1,0 +1,51 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
+import 'package:firebase_crashlytics_platform_interface/firebase_crashlytics_platform_interface.dart';
+
+import '../observer/crashlytics.dart';
+import '../test.dart';
+
+// TODO: Remove this extension once we switch to Dart3.
+extension NullableIterableExtensions<T extends Object> on Iterable<T?> {
+  /// The non-`null` elements of this iterable.
+  ///
+  /// The same elements as this iterable, except that `null` values are omitted.
+  Iterable<T> get nonNulls sync* {
+    for (final element in this) {
+      if (element != null) {
+        yield element;
+      }
+    }
+  }
+}
+
+class FakeFirebaseApp extends MockFirebaseApp {
+  static Future<void> install(TestWidgetsFlutterBinding binding) async {
+    TestFirebaseCoreHostApi.setup(FakeFirebaseApp());
+    CrashlyticsObserver(binding, throwFatalErrors: true); // Register throwing crashlytics observer.
+    await Firebase.initializeApp();
+  }
+
+  @override
+  Future<PigeonInitializeResponse> initializeApp(
+    String appName,
+    PigeonFirebaseOptions initializeAppRequest,
+  ) async {
+    var response = await super.initializeApp(appName, initializeAppRequest);
+    (response.pluginConstants.putIfAbsent(MethodChannelFirebaseCrashlytics.channel.name, () => {})!
+        as Map)['isCrashlyticsCollectionEnabled'] = false;
+    response.isAutomaticDataCollectionEnabled = false;
+    return response;
+  }
+
+  @override
+  Future<List<PigeonInitializeResponse?>> initializeCore() async {
+    var responseList = await super.initializeCore();
+    for (var response in responseList.nonNulls) {
+      (response.pluginConstants.putIfAbsent(MethodChannelFirebaseCrashlytics.channel.name, () => {})!
+          as Map)['isCrashlyticsCollectionEnabled'] = false;
+      response.isAutomaticDataCollectionEnabled = false;
+    }
+    return responseList;
+  }
+}

--- a/test/fakes/fake_firebase.dart
+++ b/test/fakes/fake_firebase.dart
@@ -5,20 +5,6 @@ import 'package:firebase_crashlytics_platform_interface/firebase_crashlytics_pla
 import '../observer/crashlytics.dart';
 import '../test.dart';
 
-// TODO: Remove this extension once we switch to Dart3.
-extension NullableIterableExtensions<T extends Object> on Iterable<T?> {
-  /// The non-`null` elements of this iterable.
-  ///
-  /// The same elements as this iterable, except that `null` values are omitted.
-  Iterable<T> get nonNulls sync* {
-    for (final element in this) {
-      if (element != null) {
-        yield element;
-      }
-    }
-  }
-}
-
 class FakeFirebaseApp extends MockFirebaseApp {
   static Future<void> install(TestWidgetsFlutterBinding binding) async {
     TestFirebaseCoreHostApi.setup(FakeFirebaseApp());

--- a/test/fakes/fake_firebase.dart
+++ b/test/fakes/fake_firebase.dart
@@ -1,5 +1,5 @@
 import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
+import 'package:firebase_core_platform_interface/test.dart';
 import 'package:firebase_crashlytics_platform_interface/firebase_crashlytics_platform_interface.dart';
 
 import '../observer/crashlytics.dart';

--- a/test/fakes/fake_sweyer_plugin_platform.dart
+++ b/test/fakes/fake_sweyer_plugin_platform.dart
@@ -1,5 +1,4 @@
-import 'dart:collection';
-
+import 'package:collection/collection.dart';
 import 'package:flutter/services.dart';
 import 'package:sweyer_plugin/sweyer_plugin.dart';
 import '../test.dart';
@@ -42,6 +41,11 @@ class FakeSweyerPluginPlatform extends SweyerPluginPlatform {
   List<Album>? albums;
   List<Playlist>? playlists;
   List<Artist>? artists;
+
+  List<Map<String, dynamic>>? rawSongs;
+  List<Map<String, dynamic>>? rawAlbums;
+  List<Map<String, dynamic>>? rawPlaylists;
+  List<Map<String, dynamic>>? rawArtists;
 
   @override
   Future<void> createPlaylist(String name) async {}
@@ -97,13 +101,20 @@ class FakeSweyerPluginPlatform extends SweyerPluginPlatform {
 
   @override
   Future<Iterable<Map<String, dynamic>>> retrieveAlbums() async {
-    final albumsList = albums ?? [albumWith()];
-    return albumsList.map((album) => album.toMap());
+    return CombinedIterableView([
+      rawAlbums,
+      albums?.map((album) => album.toMap()),
+      if (rawAlbums == null && albums == null) [albumWith().toMap()]
+    ].whereNotNull());
   }
 
   @override
   Future<Iterable<Map<String, dynamic>>> retrieveArtists() async {
-    return (artists ?? [artistWith()]).map((artist) => artist.toMap());
+    return CombinedIterableView([
+      rawArtists,
+      artists?.map((artist) => artist.toMap()),
+      if (rawArtists == null && artists == null) [artistWith().toMap()]
+    ].whereNotNull());
   }
 
   @override
@@ -113,12 +124,20 @@ class FakeSweyerPluginPlatform extends SweyerPluginPlatform {
 
   @override
   Future<Iterable<Map<String, dynamic>>> retrievePlaylists() async {
-    return (playlists ?? [playlistWith()]).map((playlist) => playlist.toMap());
+    return CombinedIterableView([
+      rawPlaylists,
+      playlists?.map((playlist) => playlist.toMap()),
+      if (rawPlaylists == null && playlists == null) [playlistWith().toMap()]
+    ].whereNotNull());
   }
 
   @override
   Future<Iterable<Map<String, dynamic>>> retrieveSongs() async {
-    return (songs ?? [songWith()]).map((song) => song.toMap());
+    return CombinedIterableView([
+      rawSongs,
+      songs?.map((song) => song.toMap()),
+      if (rawSongs == null && songs == null) [songWith().toMap()]
+    ].whereNotNull());
   }
 
   /// The log of all recorded [setSongsFavorite] calls.

--- a/test/fakes/fakes.dart
+++ b/test/fakes/fakes.dart
@@ -10,6 +10,7 @@ export 'fake_just_audio.dart';
 export 'fake_queue.dart';
 export 'fake_theme.dart';
 export 'fake_serializer.dart';
+export 'fake_firebase.dart';
 
 /// A 50x50 blue square png.
 const List<int> kBlueSquarePng = <int>[

--- a/test/logic/models/content_test.dart
+++ b/test/logic/models/content_test.dart
@@ -3,7 +3,7 @@ import 'package:collection/collection.dart';
 import '../../observer/observer.dart';
 import '../../test.dart';
 
-extension _TestMap on Map<String, dynamic> {
+extension on Map<String, dynamic> {
   Map<String, dynamic> copyWith(Map<String, dynamic> overwrites) {
     return Map.of(this)..addAll(overwrites);
   }
@@ -63,7 +63,7 @@ extension _TestMap on Map<String, dynamic> {
   }
 }
 
-extension _TestListMap on List<Map<String, dynamic>> {
+extension on List<Map<String, dynamic>> {
   List<Map<String, dynamic>> assignUniqueIds({required int startId}) {
     for (final element in this) {
       if (element['id'] is int) {

--- a/test/logic/models/content_test.dart
+++ b/test/logic/models/content_test.dart
@@ -164,18 +164,12 @@ void main() {
         (validPlaylist.copyWith({'id': 4}).copyWithout(['filesystemPath']), playlistWith(id: 4, fileSystemPath: null)),
         (validPlaylist.copyWith({'id': 5, 'dateAdded': -1}), playlistWith(id: 5, dateAdded: -1)),
         (validPlaylist.copyWith({'id': 6, 'dateModified': -1}), playlistWith(id: 6, dateModified: -1)),
-        (validPlaylist.copyWith({'id': 7, 'name': ''}), playlistWith(id: 7, name: '')),
-        (validPlaylist.copyWith({'id': 8, 'songIds': []}), playlistWith(id: 8, songIds: [])),
-        (validPlaylist.copyWith({'id': 9, 'songIds': null}), playlistWith(id: 9, songIds: [])),
-        (validPlaylist.copyWith({'id': 10}).copyWithout(['songIds']), playlistWith(id: 10, songIds: [])),
-        (
-          validPlaylist.copyWith({'id': 11, 'dateAdded': 42, 'dateModified': null}),
-          playlistWith(id: 11, dateAdded: 42, dateModified: 42)
-        ),
-        (
-          validPlaylist.copyWith({'id': 12, 'dateAdded': 42}).copyWithout(['dateModified']),
-          playlistWith(id: 12, dateAdded: 42, dateModified: 42)
-        ),
+        (validPlaylist.copyWith({'id': 7, 'dateModified': null}), playlistWith(id: 7, dateModified: null)),
+        (validPlaylist.copyWith({'id': 8}).copyWithout(['dateModified']), playlistWith(id: 8, dateModified: null)),
+        (validPlaylist.copyWith({'id': 9, 'name': ''}), playlistWith(id: 9, name: '')),
+        (validPlaylist.copyWith({'id': 10, 'songIds': []}), playlistWith(id: 10, songIds: [])),
+        (validPlaylist.copyWith({'id': 11, 'songIds': null}), playlistWith(id: 11, songIds: [])),
+        (validPlaylist.copyWith({'id': 12}).copyWithout(['songIds']), playlistWith(id: 12, songIds: [])),
         (
           validPlaylist.copyWith({
             'id': 13,
@@ -189,7 +183,6 @@ void main() {
         ...validPlaylist.copyWithout(propertiesThatCanBeMissing).subSets(),
         ...validPlaylist.withWrongTypes().whereNot(
             (map) => propertiesThatCanBeMissing.any((property) => map[property] == null) || map['songIds'] == []),
-        validPlaylist.copyWith({'dateAdded': null, 'dateModified': null}),
       ].assignUniqueIds(startId: validPlaylists.last.$2.id + 1);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
@@ -203,7 +196,7 @@ void main() {
             .map((playlist) => playlist.toMap()),
         validPlaylists.map((element) => element.$2.toMap()),
       );
-      expect(crashlyticsObserver.nonFatalErrorCount, 389);
+      expect(crashlyticsObserver.nonFatalErrorCount, 388);
     });
 
     test('Handles invalid or incomplete songs', () async {

--- a/test/logic/models/content_test.dart
+++ b/test/logic/models/content_test.dart
@@ -74,10 +74,6 @@ extension TestListMap on List<Map<String, dynamic>> {
   }
 }
 
-extension StringIterable on Iterable<String> {
-  bool containsAll(List<String> elements) => elements.every(this.contains);
-}
-
 void main() {
   group('Handles invalid or incomplete values from the media store', () {
     test('Handles invalid or incomplete albums', () async {

--- a/test/logic/models/content_test.dart
+++ b/test/logic/models/content_test.dart
@@ -1,5 +1,4 @@
 import 'package:collection/collection.dart';
-import 'package:tuple/tuple.dart';
 
 import '../../observer/observer.dart';
 import '../../test.dart';
@@ -84,23 +83,23 @@ void main() {
     test('Handles invalid or incomplete albums', () async {
       final validAlbum = albumWith().toMap();
       final validAlbums = [
-        Tuple2(validAlbum.copyWith({'id': 1}), albumWith(id: 1)),
-        Tuple2(validAlbum.copyWith({'id': 2, 'album': ''}), albumWith(id: 2, album: '')),
-        Tuple2(validAlbum.copyWith({'id': 3, 'albumArt': ''}), albumWith(id: 3, albumArt: '')),
-        Tuple2(validAlbum.copyWith({'id': 4, 'albumArt': null}), albumWith(id: 4, albumArt: null)),
-        Tuple2(validAlbum.copyWith({'id': 5}).copyWithout(['albumArt']), albumWith(id: 5, albumArt: null)),
-        Tuple2(validAlbum.copyWith({'id': 6, 'artist': ''}), albumWith(id: 6, artist: '')),
-        Tuple2(validAlbum.copyWith({'id': 7, 'artistId': -1}), albumWith(id: 7, artistId: -1)),
-        Tuple2(validAlbum.copyWith({'id': 8, 'artistId': null}), albumWith(id: 8, artistId: null)),
-        Tuple2(validAlbum.copyWith({'id': 9}).copyWithout(['artistId']), albumWith(id: 9, artistId: null)),
-        Tuple2(validAlbum.copyWith({'id': 10, 'firstYear': -1}), albumWith(id: 10, firstYear: -1)),
-        Tuple2(validAlbum.copyWith({'id': 11, 'firstYear': null}), albumWith(id: 11, firstYear: null)),
-        Tuple2(validAlbum.copyWith({'id': 12}).copyWithout(['firstYear']), albumWith(id: 12, firstYear: null)),
-        Tuple2(validAlbum.copyWith({'id': 13, 'lastYear': -1}), albumWith(id: 13, lastYear: -1)),
-        Tuple2(validAlbum.copyWith({'id': 14, 'lastYear': null}), albumWith(id: 14, lastYear: null)),
-        Tuple2(validAlbum.copyWith({'id': 15}).copyWithout(['lastYear']), albumWith(id: 15, lastYear: null)),
-        Tuple2(validAlbum.copyWith({'id': 16, 'numberOfSongs': -1}), albumWith(id: 16, numberOfSongs: -1)),
-        Tuple2(
+        (validAlbum.copyWith({'id': 1}), albumWith(id: 1)),
+        (validAlbum.copyWith({'id': 2, 'album': ''}), albumWith(id: 2, album: '')),
+        (validAlbum.copyWith({'id': 3, 'albumArt': ''}), albumWith(id: 3, albumArt: '')),
+        (validAlbum.copyWith({'id': 4, 'albumArt': null}), albumWith(id: 4, albumArt: null)),
+        (validAlbum.copyWith({'id': 5}).copyWithout(['albumArt']), albumWith(id: 5, albumArt: null)),
+        (validAlbum.copyWith({'id': 6, 'artist': ''}), albumWith(id: 6, artist: '')),
+        (validAlbum.copyWith({'id': 7, 'artistId': -1}), albumWith(id: 7, artistId: -1)),
+        (validAlbum.copyWith({'id': 8, 'artistId': null}), albumWith(id: 8, artistId: null)),
+        (validAlbum.copyWith({'id': 9}).copyWithout(['artistId']), albumWith(id: 9, artistId: null)),
+        (validAlbum.copyWith({'id': 10, 'firstYear': -1}), albumWith(id: 10, firstYear: -1)),
+        (validAlbum.copyWith({'id': 11, 'firstYear': null}), albumWith(id: 11, firstYear: null)),
+        (validAlbum.copyWith({'id': 12}).copyWithout(['firstYear']), albumWith(id: 12, firstYear: null)),
+        (validAlbum.copyWith({'id': 13, 'lastYear': -1}), albumWith(id: 13, lastYear: -1)),
+        (validAlbum.copyWith({'id': 14, 'lastYear': null}), albumWith(id: 14, lastYear: null)),
+        (validAlbum.copyWith({'id': 15}).copyWithout(['lastYear']), albumWith(id: 15, lastYear: null)),
+        (validAlbum.copyWith({'id': 16, 'numberOfSongs': -1}), albumWith(id: 16, numberOfSongs: -1)),
+        (
           validAlbum.copyWith({'id': 17, 'lastYear': 2000, 'firstYear': 3000}), // Last year before first year
           albumWith(id: 17, lastYear: 2000, firstYear: 3000),
         ),
@@ -114,16 +113,16 @@ void main() {
                   map['firstYear'] == null ||
                   map['lastYear'] == null,
             ),
-      ].assignUniqueIds(startId: validAlbums.last.item1['id'] + 1);
+      ].assignUniqueIds(startId: validAlbums.last.$1['id'] + 1);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
-        FakeSweyerPluginPlatform.instance.rawAlbums = validAlbums.map((element) => element.item1).toList()
+        FakeSweyerPluginPlatform.instance.rawAlbums = validAlbums.map((element) => element.$1).toList()
           ..addAll(invalidAlbums);
       });
       expect(
         ContentControl.instance.state.albums.values.sorted((item1, item2) => item1.id.compareTo(item2.id)),
-        validAlbums.map((element) => element.item2).toList(),
+        validAlbums.map((element) => element.$2).toList(),
       );
       expect(crashlyticsObserver.nonFatalErrorCount, 523);
     });
@@ -131,11 +130,11 @@ void main() {
     test('Handles invalid or incomplete artists', () async {
       final validArtist = artistWith().toMap();
       final validArtists = [
-        Tuple2(validArtist.copyWith({'id': 1}), artistWith(id: 1)),
-        Tuple2(validArtist.copyWith({'id': 2, 'artist': ''}), artistWith(id: 2, artist: '')),
-        Tuple2(validArtist.copyWith({'id': 3, 'numberOfAlbums': -1}), artistWith(id: 3, numberOfAlbums: -1)),
-        Tuple2(validArtist.copyWith({'id': 4, 'numberOfTracks': -1}), artistWith(id: 4, numberOfTracks: -1)),
-        Tuple2(
+        (validArtist.copyWith({'id': 1}), artistWith(id: 1)),
+        (validArtist.copyWith({'id': 2, 'artist': ''}), artistWith(id: 2, artist: '')),
+        (validArtist.copyWith({'id': 3, 'numberOfAlbums': -1}), artistWith(id: 3, numberOfAlbums: -1)),
+        (validArtist.copyWith({'id': 4, 'numberOfTracks': -1}), artistWith(id: 4, numberOfTracks: -1)),
+        (
           validArtist.copyWith({'id': 5, 'numberOfAlbums': 1, 'numberOfTracks': 0}), // No track but one album
           artistWith(id: 5, numberOfAlbums: 1, numberOfTracks: 0),
         ),
@@ -143,16 +142,16 @@ void main() {
       final invalidArtists = [
         ...validArtist.subSets(),
         ...validArtist.withWrongTypes(),
-      ].assignUniqueIds(startId: validArtists.last.item1['id'] + 1);
+      ].assignUniqueIds(startId: validArtists.last.$1['id'] + 1);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
-        FakeSweyerPluginPlatform.instance.rawArtists = validArtists.map((element) => element.item1).toList()
+        FakeSweyerPluginPlatform.instance.rawArtists = validArtists.map((element) => element.$1).toList()
           ..addAll(invalidArtists);
       });
       expect(
         ContentControl.instance.state.artists.sorted((item1, item2) => item1.id.compareTo(item2.id)),
-        validArtists.map((element) => element.item2).toList(),
+        validArtists.map((element) => element.$2).toList(),
       );
       expect(crashlyticsObserver.nonFatalErrorCount, 271);
     });
@@ -160,21 +159,21 @@ void main() {
     test('Handles invalid or incomplete playlists', () async {
       final validPlaylist = playlistWith().toMap();
       final validPlaylists = [
-        Tuple2(validPlaylist.copyWith({'id': 1}), playlistWith(id: 1)),
-        Tuple2(validPlaylist.copyWith({'id': 2, 'filesystemPath': ''}), playlistWith(id: 2, fileSystemPath: '')),
-        Tuple2(validPlaylist.copyWith({'id': 3, 'dateAdded': -1}), playlistWith(id: 3, dateAdded: -1)),
-        Tuple2(validPlaylist.copyWith({'id': 4, 'dateModified': -1}), playlistWith(id: 4, dateModified: -1)),
-        Tuple2(validPlaylist.copyWith({'id': 5, 'name': ''}), playlistWith(id: 5, name: '')),
-        Tuple2(validPlaylist.copyWith({'id': 6, 'songIds': []}), playlistWith(id: 6, songIds: [])),
-        Tuple2(
+        (validPlaylist.copyWith({'id': 1}), playlistWith(id: 1)),
+        (validPlaylist.copyWith({'id': 2, 'filesystemPath': ''}), playlistWith(id: 2, fileSystemPath: '')),
+        (validPlaylist.copyWith({'id': 3, 'dateAdded': -1}), playlistWith(id: 3, dateAdded: -1)),
+        (validPlaylist.copyWith({'id': 4, 'dateModified': -1}), playlistWith(id: 4, dateModified: -1)),
+        (validPlaylist.copyWith({'id': 5, 'name': ''}), playlistWith(id: 5, name: '')),
+        (validPlaylist.copyWith({'id': 6, 'songIds': []}), playlistWith(id: 6, songIds: [])),
+        (
           validPlaylist.copyWith({'id': 7, 'dateAdded': 42, 'dateModified': null}),
           playlistWith(id: 7, dateAdded: 42, dateModified: 42),
         ),
-        Tuple2(
+        (
           validPlaylist.copyWith({'id': 8, 'dateAdded': 42}).copyWithout(['dateModified']),
           playlistWith(id: 8, dateAdded: 42, dateModified: 42),
         ),
-        Tuple2(
+        (
           validPlaylist.copyWith({
             'id': 9,
             'songIds': [-1], // Invalid song id.
@@ -188,16 +187,16 @@ void main() {
             ].any((keys) => const SetEquality().equals(keys, map.keys.toSet()))),
         ...validPlaylist.withWrongTypes().whereNot((map) => map['dateModified'] == null || map['songIds'] == []),
         validPlaylist.copyWith({'dateAdded': null, 'dateModified': null}),
-      ].assignUniqueIds(startId: validPlaylists.last.item1['id'] + 1);
+      ].assignUniqueIds(startId: validPlaylists.last.$1['id'] + 1);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
-        FakeSweyerPluginPlatform.instance.rawPlaylists = validPlaylists.map((element) => element.item1).toList()
+        FakeSweyerPluginPlatform.instance.rawPlaylists = validPlaylists.map((element) => element.$1).toList()
           ..addAll(invalidPlaylists);
       });
       expect(
         ContentControl.instance.state.playlists.sorted((item1, item2) => item1.id.compareTo(item2.id)),
-        validPlaylists.map((element) => element.item2).toList(),
+        validPlaylists.map((element) => element.$2).toList(),
       );
       expect(crashlyticsObserver.nonFatalErrorCount, 446);
     });
@@ -205,47 +204,46 @@ void main() {
     test('Handles invalid or incomplete songs', () async {
       final validSong = songWith().toMap();
       final validSongs = [
-        Tuple2(validSong.copyWith({'id': 1}), songWith(id: 1)),
-        Tuple2(validSong.copyWith({'id': 2, 'album': ''}), songWith(id: 2, album: '')),
-        Tuple2(validSong.copyWith({'id': 3, 'album': null}), songWith(id: 3, album: null)),
-        Tuple2(validSong.copyWith({'id': 4}).copyWithout(['album']), songWith(id: 4, album: null)),
-        Tuple2(validSong.copyWith({'id': 5, 'albumId': -1}), songWith(id: 5, albumId: -1)),
-        Tuple2(validSong.copyWith({'id': 6, 'albumId': null}), songWith(id: 6, albumId: null)),
-        Tuple2(validSong.copyWith({'id': 7}).copyWithout(['albumId']), songWith(id: 7, albumId: null)),
-        Tuple2(validSong.copyWith({'id': 8, 'artist': ''}), songWith(id: 8, artist: '')),
-        Tuple2(validSong.copyWith({'id': 9, 'artistId': -1}), songWith(id: 9, artistId: -1)),
-        Tuple2(validSong.copyWith({'id': 10, 'genre': ''}), songWith(id: 10, genre: '')),
-        Tuple2(validSong.copyWith({'id': 11, 'genre': null}), songWith(id: 11, genre: null)),
-        Tuple2(validSong.copyWith({'id': 12}).copyWithout(['genre']), songWith(id: 12, genre: null)),
-        Tuple2(validSong.copyWith({'id': 13, 'genreId': -1}), songWith(id: 13, genreId: -1)),
-        Tuple2(validSong.copyWith({'id': 14, 'genreId': null}), songWith(id: 14, genreId: null)),
-        Tuple2(validSong.copyWith({'id': 15}).copyWithout(['genreId']), songWith(id: 15, genreId: null)),
-        Tuple2(validSong.copyWith({'id': 16, 'title': ''}), songWith(id: 16, title: '')),
-        Tuple2(validSong.copyWith({'id': 17, 'track': ''}), songWith(id: 17, track: '')),
-        Tuple2(validSong.copyWith({'id': 18, 'track': null}), songWith(id: 18, track: null)),
-        Tuple2(validSong.copyWith({'id': 19}).copyWithout(['track']), songWith(id: 19, track: null)),
-        Tuple2(validSong.copyWith({'id': 20, 'dateAdded': -1}), songWith(id: 20, dateAdded: -1)),
-        Tuple2(validSong.copyWith({'id': 21, 'dateModified': -1}), songWith(id: 21, dateModified: -1)),
-        Tuple2(validSong.copyWith({'id': 22, 'duration': -1}), songWith(id: 22, duration: -1)),
-        Tuple2(validSong.copyWith({'id': 23, 'size': -1}), songWith(id: 23, size: -1)),
-        Tuple2(validSong.copyWith({'id': 24, 'filesystemPath': ''}), songWith(id: 24, filesystemPath: '')),
-        Tuple2(validSong.copyWith({'id': 25, 'filesystemPath': null}), songWith(id: 25, filesystemPath: null)),
-        Tuple2(validSong.copyWith({'id': 26}).copyWithout(['filesystemPath']), songWith(id: 26, filesystemPath: null)),
-        Tuple2(
+        (validSong.copyWith({'id': 1}), songWith(id: 1)),
+        (validSong.copyWith({'id': 2, 'album': ''}), songWith(id: 2, album: '')),
+        (validSong.copyWith({'id': 3, 'album': null}), songWith(id: 3, album: null)),
+        (validSong.copyWith({'id': 4}).copyWithout(['album']), songWith(id: 4, album: null)),
+        (validSong.copyWith({'id': 5, 'albumId': -1}), songWith(id: 5, albumId: -1)),
+        (validSong.copyWith({'id': 6, 'albumId': null}), songWith(id: 6, albumId: null)),
+        (validSong.copyWith({'id': 7}).copyWithout(['albumId']), songWith(id: 7, albumId: null)),
+        (validSong.copyWith({'id': 8, 'artist': ''}), songWith(id: 8, artist: '')),
+        (validSong.copyWith({'id': 9, 'artistId': -1}), songWith(id: 9, artistId: -1)),
+        (validSong.copyWith({'id': 10, 'genre': ''}), songWith(id: 10, genre: '')),
+        (validSong.copyWith({'id': 11, 'genre': null}), songWith(id: 11, genre: null)),
+        (validSong.copyWith({'id': 12}).copyWithout(['genre']), songWith(id: 12, genre: null)),
+        (validSong.copyWith({'id': 13, 'genreId': -1}), songWith(id: 13, genreId: -1)),
+        (validSong.copyWith({'id': 14, 'genreId': null}), songWith(id: 14, genreId: null)),
+        (validSong.copyWith({'id': 15}).copyWithout(['genreId']), songWith(id: 15, genreId: null)),
+        (validSong.copyWith({'id': 16, 'title': ''}), songWith(id: 16, title: '')),
+        (validSong.copyWith({'id': 17, 'track': ''}), songWith(id: 17, track: '')),
+        (validSong.copyWith({'id': 18, 'track': null}), songWith(id: 18, track: null)),
+        (validSong.copyWith({'id': 19}).copyWithout(['track']), songWith(id: 19, track: null)),
+        (validSong.copyWith({'id': 20, 'dateAdded': -1}), songWith(id: 20, dateAdded: -1)),
+        (validSong.copyWith({'id': 21, 'dateModified': -1}), songWith(id: 21, dateModified: -1)),
+        (validSong.copyWith({'id': 22, 'duration': -1}), songWith(id: 22, duration: -1)),
+        (validSong.copyWith({'id': 23, 'size': -1}), songWith(id: 23, size: -1)),
+        (validSong.copyWith({'id': 24, 'filesystemPath': ''}), songWith(id: 24, filesystemPath: '')),
+        (validSong.copyWith({'id': 25, 'filesystemPath': null}), songWith(id: 25, filesystemPath: null)),
+        (validSong.copyWith({'id': 26}).copyWithout(['filesystemPath']), songWith(id: 26, filesystemPath: null)),
+        (
           validSong.copyWith({'id': 27, 'isFavoriteInMediaStore': null}),
-          songWith(id: 27, isFavoriteInMediaStore: null),
+          songWith(id: 27, isFavoriteInMediaStore: false),
         ),
-        Tuple2(
+        (
           validSong.copyWith({'id': 28}).copyWithout(['isFavoriteInMediaStore']),
-          songWith(id: 28, isFavoriteInMediaStore: null),
+          songWith(id: 28, isFavoriteInMediaStore: false),
         ),
-        Tuple2(validSong.copyWith({'id': 29, 'generationAdded': -1}), songWith(id: 29, generationAdded: -1)),
-        Tuple2(validSong.copyWith({'id': 30, 'generationAdded': null}), songWith(id: 30, generationAdded: null)),
-        Tuple2(
-            validSong.copyWith({'id': 31}).copyWithout(['generationAdded']), songWith(id: 31, generationAdded: null)),
-        Tuple2(validSong.copyWith({'id': 32, 'generationModified': -1}), songWith(id: 32, generationModified: -1)),
-        Tuple2(validSong.copyWith({'id': 33, 'generationModified': null}), songWith(id: 33, generationModified: null)),
-        Tuple2(
+        (validSong.copyWith({'id': 29, 'generationAdded': -1}), songWith(id: 29, generationAdded: -1)),
+        (validSong.copyWith({'id': 30, 'generationAdded': null}), songWith(id: 30, generationAdded: null)),
+        (validSong.copyWith({'id': 31}).copyWithout(['generationAdded']), songWith(id: 31, generationAdded: null)),
+        (validSong.copyWith({'id': 32, 'generationModified': -1}), songWith(id: 32, generationModified: -1)),
+        (validSong.copyWith({'id': 33, 'generationModified': null}), songWith(id: 33, generationModified: null)),
+        (
           validSong.copyWith({'id': 34}).copyWithout(['generationModified']),
           songWith(id: 34, generationModified: null),
         ),
@@ -274,16 +272,16 @@ void main() {
                   map['generationAdded'] == null ||
                   map['generationModified'] == null,
             ),
-      ].assignUniqueIds(startId: validSongs.last.item1['id'] + 1);
+      ].assignUniqueIds(startId: validSongs.last.$1['id'] + 1);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
-        FakeSweyerPluginPlatform.instance.rawSongs = validSongs.map((element) => element.item1).toList()
+        FakeSweyerPluginPlatform.instance.rawSongs = validSongs.map((element) => element.$1).toList()
           ..addAll(invalidSongs);
       });
       expect(
         ContentControl.instance.state.allSongs.songs.sorted((item1, item2) => item1.id.compareTo(item2.id)),
-        validSongs.map((element) => element.item2).toList(),
+        validSongs.map((element) => element.$2).toList(),
       );
       expect(crashlyticsObserver.nonFatalErrorCount, 1334);
     });

--- a/test/logic/models/content_test.dart
+++ b/test/logic/models/content_test.dart
@@ -4,6 +4,14 @@ import '../../observer/observer.dart';
 import '../../test.dart';
 
 extension on Map<String, dynamic> {
+  Iterable<Map<String, dynamic>> createVariantsWithMissingNonNullableElements(List<String> nullableElements) {
+    return copyWithout(nullableElements).subSets();
+  }
+
+  Iterable<Map<String, dynamic>> createVariantsWhereElementsHaveInvalidTypes(List<String> nullableElements) {
+    return withWrongTypes().whereNot((map) => nullableElements.any((property) => map[property] == null));
+  }
+
   Map<String, dynamic> copyWith(Map<String, dynamic> overwrites) {
     return Map.of(this)..addAll(overwrites);
   }
@@ -104,10 +112,8 @@ void main() {
       ];
       final propertiesThatCanBeMissing = ['albumArt', 'artistId', 'firstYear', 'lastYear', 'numberOfSongs'];
       final invalidAlbums = [
-        ...validAlbum.copyWithout(propertiesThatCanBeMissing).subSets(),
-        ...validAlbum
-            .withWrongTypes()
-            .whereNot((map) => propertiesThatCanBeMissing.any((property) => map[property] == null)),
+        ...validAlbum.createVariantsWithMissingNonNullableElements(propertiesThatCanBeMissing),
+        ...validAlbum.createVariantsWhereElementsHaveInvalidTypes(propertiesThatCanBeMissing),
       ].assignUniqueIds(startId: validAlbums.last.$2.id + 1);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
@@ -120,8 +126,13 @@ void main() {
             .sorted((item1, item2) => item1.id.compareTo(item2.id))
             .map((album) => album.toMap()),
         validAlbums.map((element) => element.$2.toMap()),
+        reason: "Should be able to correctly parse all valid albums",
       );
-      expect(crashlyticsObserver.nonFatalErrorCount, 514);
+      expect(
+        crashlyticsObserver.nonFatalErrorCount,
+        invalidAlbums.length,
+        reason: "Should reject invalid albums and report non-fatal errors",
+      );
     });
 
     test('Handles invalid or incomplete artists', () async {
@@ -136,9 +147,10 @@ void main() {
           artistWith(id: 5, numberOfAlbums: 1, numberOfTracks: 0),
         ),
       ];
+      final propertiesThatCanBeMissing = <String>[];
       final invalidArtists = [
-        ...validArtist.subSets(),
-        ...validArtist.withWrongTypes(),
+        ...validArtist.createVariantsWithMissingNonNullableElements(propertiesThatCanBeMissing),
+        ...validArtist.createVariantsWhereElementsHaveInvalidTypes(propertiesThatCanBeMissing),
       ].assignUniqueIds(startId: validArtists.last.$2.id + 1);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
@@ -151,8 +163,13 @@ void main() {
             .sorted((item1, item2) => item1.id.compareTo(item2.id))
             .map((artist) => artist.toMap()),
         validArtists.map((element) => element.$2.toMap()),
+        reason: "Should be able to correctly parse all valid artists",
       );
-      expect(crashlyticsObserver.nonFatalErrorCount, 271);
+      expect(
+        crashlyticsObserver.nonFatalErrorCount,
+        invalidArtists.length,
+        reason: "Should reject invalid artists and report non-fatal errors",
+      );
     });
 
     test('Handles invalid or incomplete playlists', () async {
@@ -180,9 +197,10 @@ void main() {
       ];
       final propertiesThatCanBeMissing = ['filesystemPath', 'dateModified', 'songIds'];
       final invalidPlaylists = [
-        ...validPlaylist.copyWithout(propertiesThatCanBeMissing).subSets(),
-        ...validPlaylist.withWrongTypes().whereNot(
-            (map) => propertiesThatCanBeMissing.any((property) => map[property] == null) || map['songIds'] == []),
+        ...validPlaylist.createVariantsWithMissingNonNullableElements(propertiesThatCanBeMissing),
+        ...validPlaylist
+            .createVariantsWhereElementsHaveInvalidTypes(propertiesThatCanBeMissing)
+            .whereNot((map) => map['songIds'] == []),
       ].assignUniqueIds(startId: validPlaylists.last.$2.id + 1);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
@@ -195,8 +213,13 @@ void main() {
             .sorted((item1, item2) => item1.id.compareTo(item2.id))
             .map((playlist) => playlist.toMap()),
         validPlaylists.map((element) => element.$2.toMap()),
+        reason: "Should be able to correctly parse all valid playlists",
       );
-      expect(crashlyticsObserver.nonFatalErrorCount, 388);
+      expect(
+        crashlyticsObserver.nonFatalErrorCount,
+        invalidPlaylists.length,
+        reason: "Should reject invalid playlists and report non-fatal errors",
+      );
     });
 
     test('Handles invalid or incomplete songs', () async {
@@ -267,10 +290,8 @@ void main() {
         'generationModified',
       ];
       final invalidSongs = [
-        ...validSong.copyWithout(propertiesThatCanBeMissing).subSets(),
-        ...validSong
-            .withWrongTypes()
-            .whereNot((map) => propertiesThatCanBeMissing.any((property) => map[property] == null))
+        ...validSong.createVariantsWithMissingNonNullableElements(propertiesThatCanBeMissing),
+        ...validSong.createVariantsWhereElementsHaveInvalidTypes(propertiesThatCanBeMissing),
       ].assignUniqueIds(startId: validSongs.last.$2.id + 1);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
@@ -283,8 +304,13 @@ void main() {
             .sorted((item1, item2) => item1.id.compareTo(item2.id))
             .map((song) => song.toMap()),
         validSongs.map((element) => element.$2.toMap()),
+        reason: "Should be able to correctly parse all valid songs",
       );
-      expect(crashlyticsObserver.nonFatalErrorCount, 1140);
+      expect(
+        crashlyticsObserver.nonFatalErrorCount,
+        invalidSongs.length,
+        reason: "Should reject invalid songs and report non-fatal errors",
+      );
     });
   });
 }

--- a/test/logic/models/content_test.dart
+++ b/test/logic/models/content_test.dart
@@ -1,0 +1,291 @@
+import 'package:collection/collection.dart';
+import 'package:tuple/tuple.dart';
+
+import '../../observer/observer.dart';
+import '../../test.dart';
+
+extension TestMap on Map<String, dynamic> {
+  Map<String, dynamic> copyWith(Map<String, dynamic> overwrites) {
+    return Map.of(this)..addAll(overwrites);
+  }
+
+  Map<String, dynamic> copyWithout(List<String> keysToRemove) {
+    var map = Map.of(this);
+    keysToRemove.forEach(map.remove);
+    return map;
+  }
+
+  Iterable<Map<String, dynamic>> subSets() sync* {
+    var subSets = [[]];
+    yield {};
+    for (final key in keys) {
+      for (var subSet in subSets.toList()) {
+        var newSubSet = subSet + [key];
+        if (newSubSet.length >= keys.length) {
+          continue;
+        }
+        yield Map.fromEntries(entries.where((entry) => newSubSet.contains(entry.key)));
+        subSets.add(newSubSet);
+      }
+    }
+  }
+
+  Iterable<Map<String, dynamic>> withWrongTypes() sync* {
+    Iterable<dynamic> createVariations<T>(T value) sync* {
+      yield value;
+      yield [value];
+      yield {value};
+      yield {value: null};
+      yield {null: value};
+      yield {value: true};
+      yield {true: value};
+      yield {value: 0};
+      yield {0: value};
+      yield {value: double.nan};
+      yield {double.nan: value};
+      yield {value: ""};
+      yield {"": value};
+    }
+
+    final wrongTypeValues = [
+      ...createVariations(null),
+      ...createVariations(true),
+      ...createVariations(0),
+      ...createVariations(double.nan),
+      ...createVariations(""),
+    ];
+    for (final key in keys) {
+      for (final wrongTypeValue in wrongTypeValues) {
+        if (this[key].runtimeType != wrongTypeValue.runtimeType) {
+          yield Map.of(this)..[key] = wrongTypeValue;
+        }
+      }
+    }
+  }
+}
+
+extension TestListMap on List<Map<String, dynamic>> {
+  List<Map<String, dynamic>> assignUniqueIds({required int startId}) {
+    for (var element in this) {
+      if (element['id'] is int) {
+        element['id'] = startId++;
+      }
+    }
+    return this;
+  }
+}
+
+extension StringIterable on Iterable<String> {
+  bool containsAll(List<String> elements) => elements.every(this.contains);
+}
+
+void main() {
+  group('Handles invalid or incomplete values from the media store', () {
+    test('Handles invalid or incomplete albums', () async {
+      final validAlbum = albumWith().toMap();
+      final validAlbums = [
+        Tuple2(validAlbum.copyWith({'id': 1}), albumWith(id: 1)),
+        Tuple2(validAlbum.copyWith({'id': 2, 'album': ''}), albumWith(id: 2, album: '')),
+        Tuple2(validAlbum.copyWith({'id': 3, 'albumArt': ''}), albumWith(id: 3, albumArt: '')),
+        Tuple2(validAlbum.copyWith({'id': 4, 'albumArt': null}), albumWith(id: 4, albumArt: null)),
+        Tuple2(validAlbum.copyWith({'id': 5}).copyWithout(['albumArt']), albumWith(id: 5, albumArt: null)),
+        Tuple2(validAlbum.copyWith({'id': 6, 'artist': ''}), albumWith(id: 6, artist: '')),
+        Tuple2(validAlbum.copyWith({'id': 7, 'artistId': -1}), albumWith(id: 7, artistId: -1)),
+        Tuple2(validAlbum.copyWith({'id': 8, 'artistId': null}), albumWith(id: 8, artistId: null)),
+        Tuple2(validAlbum.copyWith({'id': 9}).copyWithout(['artistId']), albumWith(id: 9, artistId: null)),
+        Tuple2(validAlbum.copyWith({'id': 10, 'firstYear': -1}), albumWith(id: 10, firstYear: -1)),
+        Tuple2(validAlbum.copyWith({'id': 11, 'firstYear': null}), albumWith(id: 11, firstYear: null)),
+        Tuple2(validAlbum.copyWith({'id': 12}).copyWithout(['firstYear']), albumWith(id: 12, firstYear: null)),
+        Tuple2(validAlbum.copyWith({'id': 13, 'lastYear': -1}), albumWith(id: 13, lastYear: -1)),
+        Tuple2(validAlbum.copyWith({'id': 14, 'lastYear': null}), albumWith(id: 14, lastYear: null)),
+        Tuple2(validAlbum.copyWith({'id': 15}).copyWithout(['lastYear']), albumWith(id: 15, lastYear: null)),
+        Tuple2(validAlbum.copyWith({'id': 16, 'numberOfSongs': -1}), albumWith(id: 16, numberOfSongs: -1)),
+        Tuple2(
+          validAlbum.copyWith({'id': 17, 'lastYear': 2000, 'firstYear': 3000}), // Last year before first year
+          albumWith(id: 17, lastYear: 2000, firstYear: 3000),
+        ),
+      ];
+      final invalidAlbums = [
+        ...validAlbum.copyWithout(['albumArt', 'artistId', 'firstYear', 'lastYear']).subSets(),
+        ...validAlbum.withWrongTypes().whereNot(
+              (map) =>
+                  map['albumArt'] == null ||
+                  map['artistId'] == null ||
+                  map['firstYear'] == null ||
+                  map['lastYear'] == null,
+            ),
+      ].assignUniqueIds(startId: validAlbums.last.item1['id'] + 1);
+      late CrashlyticsObserver crashlyticsObserver;
+      await setUpAppTest(() {
+        crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
+        FakeSweyerPluginPlatform.instance.rawAlbums = validAlbums.map((element) => element.item1).toList()
+          ..addAll(invalidAlbums);
+      });
+      expect(
+        ContentControl.instance.state.albums.values.sorted((item1, item2) => item1.id.compareTo(item2.id)),
+        validAlbums.map((element) => element.item2).toList(),
+      );
+      expect(crashlyticsObserver.nonFatalErrorCount, 523);
+    });
+
+    test('Handles invalid or incomplete artists', () async {
+      final validArtist = artistWith().toMap();
+      final validArtists = [
+        Tuple2(validArtist.copyWith({'id': 1}), artistWith(id: 1)),
+        Tuple2(validArtist.copyWith({'id': 2, 'artist': ''}), artistWith(id: 2, artist: '')),
+        Tuple2(validArtist.copyWith({'id': 3, 'numberOfAlbums': -1}), artistWith(id: 3, numberOfAlbums: -1)),
+        Tuple2(validArtist.copyWith({'id': 4, 'numberOfTracks': -1}), artistWith(id: 4, numberOfTracks: -1)),
+        Tuple2(
+          validArtist.copyWith({'id': 5, 'numberOfAlbums': 1, 'numberOfTracks': 0}), // No track but one album
+          artistWith(id: 5, numberOfAlbums: 1, numberOfTracks: 0),
+        ),
+      ];
+      final invalidArtists = [
+        ...validArtist.subSets(),
+        ...validArtist.withWrongTypes(),
+      ].assignUniqueIds(startId: validArtists.last.item1['id'] + 1);
+      late CrashlyticsObserver crashlyticsObserver;
+      await setUpAppTest(() {
+        crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
+        FakeSweyerPluginPlatform.instance.rawArtists = validArtists.map((element) => element.item1).toList()
+          ..addAll(invalidArtists);
+      });
+      expect(
+        ContentControl.instance.state.artists.sorted((item1, item2) => item1.id.compareTo(item2.id)),
+        validArtists.map((element) => element.item2).toList(),
+      );
+      expect(crashlyticsObserver.nonFatalErrorCount, 271);
+    });
+
+    test('Handles invalid or incomplete playlists', () async {
+      final validPlaylist = playlistWith().toMap();
+      final validPlaylists = [
+        Tuple2(validPlaylist.copyWith({'id': 1}), playlistWith(id: 1)),
+        Tuple2(validPlaylist.copyWith({'id': 2, 'filesystemPath': ''}), playlistWith(id: 2, fileSystemPath: '')),
+        Tuple2(validPlaylist.copyWith({'id': 3, 'dateAdded': -1}), playlistWith(id: 3, dateAdded: -1)),
+        Tuple2(validPlaylist.copyWith({'id': 4, 'dateModified': -1}), playlistWith(id: 4, dateModified: -1)),
+        Tuple2(validPlaylist.copyWith({'id': 5, 'name': ''}), playlistWith(id: 5, name: '')),
+        Tuple2(validPlaylist.copyWith({'id': 6, 'songIds': []}), playlistWith(id: 6, songIds: [])),
+        Tuple2(
+          validPlaylist.copyWith({'id': 7, 'dateAdded': 42, 'dateModified': null}),
+          playlistWith(id: 7, dateAdded: 42, dateModified: 42),
+        ),
+        Tuple2(
+          validPlaylist.copyWith({'id': 8, 'dateAdded': 42}).copyWithout(['dateModified']),
+          playlistWith(id: 8, dateAdded: 42, dateModified: 42),
+        ),
+        Tuple2(
+          validPlaylist.copyWith({
+            'id': 9,
+            'songIds': [-1], // Invalid song id.
+          }),
+          playlistWith(id: 9, songIds: [-1]),
+        ),
+      ];
+      final invalidPlaylists = [
+        ...validPlaylist.subSets().whereNot((map) => [
+              {'id', 'filesystemPath', 'dateAdded', 'name', 'songIds'},
+            ].any((keys) => const SetEquality().equals(keys, map.keys.toSet()))),
+        ...validPlaylist.withWrongTypes().whereNot((map) => map['dateModified'] == null || map['songIds'] == []),
+        validPlaylist.copyWith({'dateAdded': null, 'dateModified': null}),
+      ].assignUniqueIds(startId: validPlaylists.last.item1['id'] + 1);
+      late CrashlyticsObserver crashlyticsObserver;
+      await setUpAppTest(() {
+        crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
+        FakeSweyerPluginPlatform.instance.rawPlaylists = validPlaylists.map((element) => element.item1).toList()
+          ..addAll(invalidPlaylists);
+      });
+      expect(
+        ContentControl.instance.state.playlists.sorted((item1, item2) => item1.id.compareTo(item2.id)),
+        validPlaylists.map((element) => element.item2).toList(),
+      );
+      expect(crashlyticsObserver.nonFatalErrorCount, 446);
+    });
+
+    test('Handles invalid or incomplete songs', () async {
+      final validSong = songWith().toMap();
+      final validSongs = [
+        Tuple2(validSong.copyWith({'id': 1}), songWith(id: 1)),
+        Tuple2(validSong.copyWith({'id': 2, 'album': ''}), songWith(id: 2, album: '')),
+        Tuple2(validSong.copyWith({'id': 3, 'album': null}), songWith(id: 3, album: null)),
+        Tuple2(validSong.copyWith({'id': 4}).copyWithout(['album']), songWith(id: 4, album: null)),
+        Tuple2(validSong.copyWith({'id': 5, 'albumId': -1}), songWith(id: 5, albumId: -1)),
+        Tuple2(validSong.copyWith({'id': 6, 'albumId': null}), songWith(id: 6, albumId: null)),
+        Tuple2(validSong.copyWith({'id': 7}).copyWithout(['albumId']), songWith(id: 7, albumId: null)),
+        Tuple2(validSong.copyWith({'id': 8, 'artist': ''}), songWith(id: 8, artist: '')),
+        Tuple2(validSong.copyWith({'id': 9, 'artistId': -1}), songWith(id: 9, artistId: -1)),
+        Tuple2(validSong.copyWith({'id': 10, 'genre': ''}), songWith(id: 10, genre: '')),
+        Tuple2(validSong.copyWith({'id': 11, 'genre': null}), songWith(id: 11, genre: null)),
+        Tuple2(validSong.copyWith({'id': 12}).copyWithout(['genre']), songWith(id: 12, genre: null)),
+        Tuple2(validSong.copyWith({'id': 13, 'genreId': -1}), songWith(id: 13, genreId: -1)),
+        Tuple2(validSong.copyWith({'id': 14, 'genreId': null}), songWith(id: 14, genreId: null)),
+        Tuple2(validSong.copyWith({'id': 15}).copyWithout(['genreId']), songWith(id: 15, genreId: null)),
+        Tuple2(validSong.copyWith({'id': 16, 'title': ''}), songWith(id: 16, title: '')),
+        Tuple2(validSong.copyWith({'id': 17, 'track': ''}), songWith(id: 17, track: '')),
+        Tuple2(validSong.copyWith({'id': 18, 'track': null}), songWith(id: 18, track: null)),
+        Tuple2(validSong.copyWith({'id': 19}).copyWithout(['track']), songWith(id: 19, track: null)),
+        Tuple2(validSong.copyWith({'id': 20, 'dateAdded': -1}), songWith(id: 20, dateAdded: -1)),
+        Tuple2(validSong.copyWith({'id': 21, 'dateModified': -1}), songWith(id: 21, dateModified: -1)),
+        Tuple2(validSong.copyWith({'id': 22, 'duration': -1}), songWith(id: 22, duration: -1)),
+        Tuple2(validSong.copyWith({'id': 23, 'size': -1}), songWith(id: 23, size: -1)),
+        Tuple2(validSong.copyWith({'id': 24, 'filesystemPath': ''}), songWith(id: 24, filesystemPath: '')),
+        Tuple2(validSong.copyWith({'id': 25, 'filesystemPath': null}), songWith(id: 25, filesystemPath: null)),
+        Tuple2(validSong.copyWith({'id': 26}).copyWithout(['filesystemPath']), songWith(id: 26, filesystemPath: null)),
+        Tuple2(
+          validSong.copyWith({'id': 27, 'isFavoriteInMediaStore': null}),
+          songWith(id: 27, isFavoriteInMediaStore: null),
+        ),
+        Tuple2(
+          validSong.copyWith({'id': 28}).copyWithout(['isFavoriteInMediaStore']),
+          songWith(id: 28, isFavoriteInMediaStore: null),
+        ),
+        Tuple2(validSong.copyWith({'id': 29, 'generationAdded': -1}), songWith(id: 29, generationAdded: -1)),
+        Tuple2(validSong.copyWith({'id': 30, 'generationAdded': null}), songWith(id: 30, generationAdded: null)),
+        Tuple2(
+            validSong.copyWith({'id': 31}).copyWithout(['generationAdded']), songWith(id: 31, generationAdded: null)),
+        Tuple2(validSong.copyWith({'id': 32, 'generationModified': -1}), songWith(id: 32, generationModified: -1)),
+        Tuple2(validSong.copyWith({'id': 33, 'generationModified': null}), songWith(id: 33, generationModified: null)),
+        Tuple2(
+          validSong.copyWith({'id': 34}).copyWithout(['generationModified']),
+          songWith(id: 34, generationModified: null),
+        ),
+      ];
+      final invalidSongs = [
+        ...validSong.copyWithout([
+          'album',
+          'albumId',
+          'genre',
+          'genreId',
+          'track',
+          'filesystemPath',
+          'isFavoriteInMediaStore',
+          'generationAdded',
+          'generationModified',
+        ]).subSets(),
+        ...validSong.withWrongTypes().whereNot(
+              (map) =>
+                  map['album'] == null ||
+                  map['albumId'] == null ||
+                  map['genre'] == null ||
+                  map['genreId'] == null ||
+                  map['track'] == null ||
+                  map['filesystemPath'] == null ||
+                  map['isFavoriteInMediaStore'] == null ||
+                  map['generationAdded'] == null ||
+                  map['generationModified'] == null,
+            ),
+      ].assignUniqueIds(startId: validSongs.last.item1['id'] + 1);
+      late CrashlyticsObserver crashlyticsObserver;
+      await setUpAppTest(() {
+        crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
+        FakeSweyerPluginPlatform.instance.rawSongs = validSongs.map((element) => element.item1).toList()
+          ..addAll(invalidSongs);
+      });
+      expect(
+        ContentControl.instance.state.allSongs.songs.sorted((item1, item2) => item1.id.compareTo(item2.id)),
+        validSongs.map((element) => element.item2).toList(),
+      );
+      expect(crashlyticsObserver.nonFatalErrorCount, 1334);
+    });
+  });
+}

--- a/test/logic/models/content_test.dart
+++ b/test/logic/models/content_test.dart
@@ -83,8 +83,8 @@ extension on List<Map<String, dynamic>> {
 }
 
 void main() {
-  group('Handles invalid or incomplete values from the media store', () {
-    test('Handles invalid or incomplete albums', () async {
+  group('Handles valid values from the media store', () {
+    test('Handles valid albums', () async {
       final validAlbum = albumWith().toMap();
       final validAlbums = [
         (validAlbum.copyWith({'id': 1}), albumWith(id: 1)),
@@ -110,16 +110,10 @@ void main() {
           albumWith(id: 19, lastYear: 2000, firstYear: 3000),
         ),
       ];
-      final propertiesThatCanBeMissing = ['albumArt', 'artistId', 'firstYear', 'lastYear', 'numberOfSongs'];
-      final invalidAlbums = [
-        ...validAlbum.createVariantsWithMissingNonNullableElements(propertiesThatCanBeMissing),
-        ...validAlbum.createVariantsWhereElementsHaveInvalidTypes(propertiesThatCanBeMissing),
-      ].assignUniqueIds(startId: validAlbums.last.$2.id + 1);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
-        FakeSweyerPluginPlatform.instance.rawAlbums = validAlbums.map((element) => element.$1).toList()
-          ..addAll(invalidAlbums);
+        FakeSweyerPluginPlatform.instance.rawAlbums = validAlbums.map((element) => element.$1).toList();
       });
       expect(
         ContentControl.instance.state.albums.values
@@ -128,14 +122,10 @@ void main() {
         validAlbums.map((element) => element.$2.toMap()),
         reason: "Should be able to correctly parse all valid albums",
       );
-      expect(
-        crashlyticsObserver.nonFatalErrorCount,
-        invalidAlbums.length,
-        reason: "Should reject invalid albums and report non-fatal errors",
-      );
+      expect(crashlyticsObserver.nonFatalErrorCount, 0, reason: "Should not reject any valid albums");
     });
 
-    test('Handles invalid or incomplete artists', () async {
+    test('Handles valid artists', () async {
       final validArtist = artistWith().toMap();
       final validArtists = [
         (validArtist.copyWith({'id': 1}), artistWith(id: 1)),
@@ -147,16 +137,10 @@ void main() {
           artistWith(id: 5, numberOfAlbums: 1, numberOfTracks: 0),
         ),
       ];
-      final propertiesThatCanBeMissing = <String>[];
-      final invalidArtists = [
-        ...validArtist.createVariantsWithMissingNonNullableElements(propertiesThatCanBeMissing),
-        ...validArtist.createVariantsWhereElementsHaveInvalidTypes(propertiesThatCanBeMissing),
-      ].assignUniqueIds(startId: validArtists.last.$2.id + 1);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
-        FakeSweyerPluginPlatform.instance.rawArtists = validArtists.map((element) => element.$1).toList()
-          ..addAll(invalidArtists);
+        FakeSweyerPluginPlatform.instance.rawArtists = validArtists.map((element) => element.$1).toList();
       });
       expect(
         ContentControl.instance.state.artists
@@ -165,14 +149,10 @@ void main() {
         validArtists.map((element) => element.$2.toMap()),
         reason: "Should be able to correctly parse all valid artists",
       );
-      expect(
-        crashlyticsObserver.nonFatalErrorCount,
-        invalidArtists.length,
-        reason: "Should reject invalid artists and report non-fatal errors",
-      );
+      expect(crashlyticsObserver.nonFatalErrorCount, 0, reason: "Should not reject any valid artists");
     });
 
-    test('Handles invalid or incomplete playlists', () async {
+    test('Handles valid playlists', () async {
       final validPlaylist = playlistWith().toMap();
       final validPlaylists = [
         (validPlaylist.copyWith({'id': 1}), playlistWith(id: 1)),
@@ -195,18 +175,10 @@ void main() {
           playlistWith(id: 13, songIds: [-1])
         ),
       ];
-      final propertiesThatCanBeMissing = ['filesystemPath', 'dateModified', 'songIds'];
-      final invalidPlaylists = [
-        ...validPlaylist.createVariantsWithMissingNonNullableElements(propertiesThatCanBeMissing),
-        ...validPlaylist
-            .createVariantsWhereElementsHaveInvalidTypes(propertiesThatCanBeMissing)
-            .whereNot((map) => map['songIds'] == []),
-      ].assignUniqueIds(startId: validPlaylists.last.$2.id + 1);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
-        FakeSweyerPluginPlatform.instance.rawPlaylists = validPlaylists.map((element) => element.$1).toList()
-          ..addAll(invalidPlaylists);
+        FakeSweyerPluginPlatform.instance.rawPlaylists = validPlaylists.map((element) => element.$1).toList();
       });
       expect(
         ContentControl.instance.state.playlists
@@ -215,14 +187,10 @@ void main() {
         validPlaylists.map((element) => element.$2.toMap()),
         reason: "Should be able to correctly parse all valid playlists",
       );
-      expect(
-        crashlyticsObserver.nonFatalErrorCount,
-        invalidPlaylists.length,
-        reason: "Should reject invalid playlists and report non-fatal errors",
-      );
+      expect(crashlyticsObserver.nonFatalErrorCount, 0, reason: "Should not reject any playlists");
     });
 
-    test('Handles invalid or incomplete songs', () async {
+    test('Handles valid songs', () async {
       final validSong = songWith().toMap();
       final validSongs = [
         (validSong.copyWith({'id': 1}), songWith(id: 1)),
@@ -276,6 +244,105 @@ void main() {
           songWith(id: 38, generationModified: null)
         ),
       ];
+      late CrashlyticsObserver crashlyticsObserver;
+      await setUpAppTest(() {
+        crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
+        FakeSweyerPluginPlatform.instance.rawSongs = validSongs.map((element) => element.$1).toList();
+      });
+      expect(
+        ContentControl.instance.state.allSongs.songs
+            .sorted((item1, item2) => item1.id.compareTo(item2.id))
+            .map((song) => song.toMap()),
+        validSongs.map((element) => element.$2.toMap()),
+        reason: "Should be able to correctly parse all valid songs",
+      );
+      expect(crashlyticsObserver.nonFatalErrorCount, 0, reason: "Should not reject any valid songs");
+    });
+  });
+
+  group('Handles invalid or incomplete values from the media store', () {
+    test('Handles invalid or incomplete albums', () async {
+      final validAlbum = albumWith().toMap();
+      final propertiesThatCanBeMissing = ['albumArt', 'artistId', 'firstYear', 'lastYear', 'numberOfSongs'];
+      final invalidAlbums = [
+        ...validAlbum.createVariantsWithMissingNonNullableElements(propertiesThatCanBeMissing),
+        ...validAlbum.createVariantsWhereElementsHaveInvalidTypes(propertiesThatCanBeMissing),
+      ].assignUniqueIds(startId: 0);
+      late CrashlyticsObserver crashlyticsObserver;
+      await setUpAppTest(() {
+        crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
+        FakeSweyerPluginPlatform.instance.rawAlbums = invalidAlbums;
+      });
+      expect(
+        ContentControl.instance.state.albums.values
+            .sorted((item1, item2) => item1.id.compareTo(item2.id))
+            .map((album) => album.toMap()),
+        [],
+        reason: "Should not accept any invalid albums",
+      );
+      expect(
+        crashlyticsObserver.nonFatalErrorCount,
+        invalidAlbums.length,
+        reason: "Should reject invalid albums and report non-fatal errors",
+      );
+    });
+
+    test('Handles invalid or incomplete artists', () async {
+      final validArtist = artistWith().toMap();
+      final propertiesThatCanBeMissing = <String>[];
+      final invalidArtists = [
+        ...validArtist.createVariantsWithMissingNonNullableElements(propertiesThatCanBeMissing),
+        ...validArtist.createVariantsWhereElementsHaveInvalidTypes(propertiesThatCanBeMissing),
+      ].assignUniqueIds(startId: 0);
+      late CrashlyticsObserver crashlyticsObserver;
+      await setUpAppTest(() {
+        crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
+        FakeSweyerPluginPlatform.instance.rawArtists = invalidArtists;
+      });
+      expect(
+        ContentControl.instance.state.artists
+            .sorted((item1, item2) => item1.id.compareTo(item2.id))
+            .map((artist) => artist.toMap()),
+        [],
+        reason: "Should not accept any invalid artists",
+      );
+      expect(
+        crashlyticsObserver.nonFatalErrorCount,
+        invalidArtists.length,
+        reason: "Should reject invalid artists and report non-fatal errors",
+      );
+    });
+
+    test('Handles invalid or incomplete playlists', () async {
+      final validPlaylist = playlistWith().toMap();
+      final propertiesThatCanBeMissing = ['filesystemPath', 'dateModified', 'songIds'];
+      final invalidPlaylists = [
+        ...validPlaylist.createVariantsWithMissingNonNullableElements(propertiesThatCanBeMissing),
+        ...validPlaylist
+            .createVariantsWhereElementsHaveInvalidTypes(propertiesThatCanBeMissing)
+            .whereNot((map) => map['songIds'] == []),
+      ].assignUniqueIds(startId: 0);
+      late CrashlyticsObserver crashlyticsObserver;
+      await setUpAppTest(() {
+        crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
+        FakeSweyerPluginPlatform.instance.rawPlaylists = invalidPlaylists;
+      });
+      expect(
+        ContentControl.instance.state.playlists
+            .sorted((item1, item2) => item1.id.compareTo(item2.id))
+            .map((playlist) => playlist.toMap()),
+        [],
+        reason: "Should not accept any invalid playlists",
+      );
+      expect(
+        crashlyticsObserver.nonFatalErrorCount,
+        invalidPlaylists.length,
+        reason: "Should reject invalid playlists and report non-fatal errors",
+      );
+    });
+
+    test('Handles invalid or incomplete songs', () async {
+      final validSong = songWith().toMap();
       final propertiesThatCanBeMissing = [
         'album',
         'albumId',
@@ -292,19 +359,19 @@ void main() {
       final invalidSongs = [
         ...validSong.createVariantsWithMissingNonNullableElements(propertiesThatCanBeMissing),
         ...validSong.createVariantsWhereElementsHaveInvalidTypes(propertiesThatCanBeMissing),
-      ].assignUniqueIds(startId: validSongs.last.$2.id + 1);
+      ].assignUniqueIds(startId: 0);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
-        FakeSweyerPluginPlatform.instance.rawSongs = validSongs.map((element) => element.$1).toList()
-          ..addAll(invalidSongs);
+        FakeSweyerPluginPlatform.instance.rawSongs = invalidSongs;
       });
       expect(
-        ContentControl.instance.state.allSongs.songs
+        // The state is disposed if there is not songs, so use an empty list in that case.
+        (ContentControl.instance.stateNullable?.allSongs.songs ?? [])
             .sorted((item1, item2) => item1.id.compareTo(item2.id))
             .map((song) => song.toMap()),
-        validSongs.map((element) => element.$2.toMap()),
-        reason: "Should be able to correctly parse all valid songs",
+        [],
+        reason: "Should not accept any invalid songs",
       );
       expect(
         crashlyticsObserver.nonFatalErrorCount,

--- a/test/logic/models/content_test.dart
+++ b/test/logic/models/content_test.dart
@@ -3,7 +3,7 @@ import 'package:collection/collection.dart';
 import '../../observer/observer.dart';
 import '../../test.dart';
 
-extension TestMap on Map<String, dynamic> {
+extension _TestMap on Map<String, dynamic> {
   Map<String, dynamic> copyWith(Map<String, dynamic> overwrites) {
     return Map.of(this)..addAll(overwrites);
   }
@@ -63,7 +63,7 @@ extension TestMap on Map<String, dynamic> {
   }
 }
 
-extension TestListMap on List<Map<String, dynamic>> {
+extension _TestListMap on List<Map<String, dynamic>> {
   List<Map<String, dynamic>> assignUniqueIds({required int startId}) {
     for (var element in this) {
       if (element['id'] is int) {

--- a/test/logic/models/content_test.dart
+++ b/test/logic/models/content_test.dart
@@ -99,21 +99,20 @@ void main() {
         (validAlbum.copyWith({'id': 14, 'lastYear': null}), albumWith(id: 14, lastYear: null)),
         (validAlbum.copyWith({'id': 15}).copyWithout(['lastYear']), albumWith(id: 15, lastYear: null)),
         (validAlbum.copyWith({'id': 16, 'numberOfSongs': -1}), albumWith(id: 16, numberOfSongs: -1)),
+        (validAlbum.copyWith({'id': 17, 'numberOfSongs': null}), albumWith(id: 17, numberOfSongs: 0)),
+        (validAlbum.copyWith({'id': 18}).copyWithout(['numberOfSongs']), albumWith(id: 18, numberOfSongs: 0)),
         (
-          validAlbum.copyWith({'id': 17, 'lastYear': 2000, 'firstYear': 3000}), // Last year before first year
-          albumWith(id: 17, lastYear: 2000, firstYear: 3000),
+          validAlbum.copyWith({'id': 19, 'lastYear': 2000, 'firstYear': 3000}), // Last year before first year
+          albumWith(id: 19, lastYear: 2000, firstYear: 3000),
         ),
       ];
+      final propertiesThatCanBeMissing = ['albumArt', 'artistId', 'firstYear', 'lastYear', 'numberOfSongs'];
       final invalidAlbums = [
-        ...validAlbum.copyWithout(['albumArt', 'artistId', 'firstYear', 'lastYear']).subSets(),
-        ...validAlbum.withWrongTypes().whereNot(
-              (map) =>
-                  map['albumArt'] == null ||
-                  map['artistId'] == null ||
-                  map['firstYear'] == null ||
-                  map['lastYear'] == null,
-            ),
-      ].assignUniqueIds(startId: validAlbums.last.$1['id'] + 1);
+        ...validAlbum.copyWithout(propertiesThatCanBeMissing).subSets(),
+        ...validAlbum
+            .withWrongTypes()
+            .whereNot((map) => propertiesThatCanBeMissing.any((property) => map[property] == null)),
+      ].assignUniqueIds(startId: validAlbums.last.$2.id + 1);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
@@ -121,10 +120,12 @@ void main() {
           ..addAll(invalidAlbums);
       });
       expect(
-        ContentControl.instance.state.albums.values.sorted((item1, item2) => item1.id.compareTo(item2.id)),
-        validAlbums.map((element) => element.$2).toList(),
+        ContentControl.instance.state.albums.values
+            .sorted((item1, item2) => item1.id.compareTo(item2.id))
+            .map((album) => album.toMap()),
+        validAlbums.map((element) => element.$2.toMap()),
       );
-      expect(crashlyticsObserver.nonFatalErrorCount, 523);
+      expect(crashlyticsObserver.nonFatalErrorCount, 514);
     });
 
     test('Handles invalid or incomplete artists', () async {
@@ -142,7 +143,7 @@ void main() {
       final invalidArtists = [
         ...validArtist.subSets(),
         ...validArtist.withWrongTypes(),
-      ].assignUniqueIds(startId: validArtists.last.$1['id'] + 1);
+      ].assignUniqueIds(startId: validArtists.last.$2.id + 1);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
@@ -150,8 +151,10 @@ void main() {
           ..addAll(invalidArtists);
       });
       expect(
-        ContentControl.instance.state.artists.sorted((item1, item2) => item1.id.compareTo(item2.id)),
-        validArtists.map((element) => element.$2).toList(),
+        ContentControl.instance.state.artists
+            .sorted((item1, item2) => item1.id.compareTo(item2.id))
+            .map((artist) => artist.toMap()),
+        validArtists.map((element) => element.$2.toMap()),
       );
       expect(crashlyticsObserver.nonFatalErrorCount, 271);
     });
@@ -161,33 +164,37 @@ void main() {
       final validPlaylists = [
         (validPlaylist.copyWith({'id': 1}), playlistWith(id: 1)),
         (validPlaylist.copyWith({'id': 2, 'filesystemPath': ''}), playlistWith(id: 2, fileSystemPath: '')),
-        (validPlaylist.copyWith({'id': 3, 'dateAdded': -1}), playlistWith(id: 3, dateAdded: -1)),
-        (validPlaylist.copyWith({'id': 4, 'dateModified': -1}), playlistWith(id: 4, dateModified: -1)),
-        (validPlaylist.copyWith({'id': 5, 'name': ''}), playlistWith(id: 5, name: '')),
-        (validPlaylist.copyWith({'id': 6, 'songIds': []}), playlistWith(id: 6, songIds: [])),
+        (validPlaylist.copyWith({'id': 3, 'filesystemPath': null}), playlistWith(id: 3, fileSystemPath: null)),
+        (validPlaylist.copyWith({'id': 4}).copyWithout(['filesystemPath']), playlistWith(id: 4, fileSystemPath: null)),
+        (validPlaylist.copyWith({'id': 5, 'dateAdded': -1}), playlistWith(id: 5, dateAdded: -1)),
+        (validPlaylist.copyWith({'id': 6, 'dateModified': -1}), playlistWith(id: 6, dateModified: -1)),
+        (validPlaylist.copyWith({'id': 7, 'name': ''}), playlistWith(id: 7, name: '')),
+        (validPlaylist.copyWith({'id': 8, 'songIds': []}), playlistWith(id: 8, songIds: [])),
+        (validPlaylist.copyWith({'id': 9, 'songIds': null}), playlistWith(id: 9, songIds: [])),
+        (validPlaylist.copyWith({'id': 10}).copyWithout(['songIds']), playlistWith(id: 10, songIds: [])),
         (
-          validPlaylist.copyWith({'id': 7, 'dateAdded': 42, 'dateModified': null}),
-          playlistWith(id: 7, dateAdded: 42, dateModified: 42),
+          validPlaylist.copyWith({'id': 11, 'dateAdded': 42, 'dateModified': null}),
+          playlistWith(id: 11, dateAdded: 42, dateModified: 42)
         ),
         (
-          validPlaylist.copyWith({'id': 8, 'dateAdded': 42}).copyWithout(['dateModified']),
-          playlistWith(id: 8, dateAdded: 42, dateModified: 42),
+          validPlaylist.copyWith({'id': 12, 'dateAdded': 42}).copyWithout(['dateModified']),
+          playlistWith(id: 12, dateAdded: 42, dateModified: 42)
         ),
         (
           validPlaylist.copyWith({
-            'id': 9,
+            'id': 13,
             'songIds': [-1], // Invalid song id.
           }),
-          playlistWith(id: 9, songIds: [-1]),
+          playlistWith(id: 13, songIds: [-1])
         ),
       ];
+      final propertiesThatCanBeMissing = ['filesystemPath', 'dateModified', 'songIds'];
       final invalidPlaylists = [
-        ...validPlaylist.subSets().whereNot((map) => [
-              {'id', 'filesystemPath', 'dateAdded', 'name', 'songIds'},
-            ].any((keys) => const SetEquality().equals(keys, map.keys.toSet()))),
-        ...validPlaylist.withWrongTypes().whereNot((map) => map['dateModified'] == null || map['songIds'] == []),
+        ...validPlaylist.copyWithout(propertiesThatCanBeMissing).subSets(),
+        ...validPlaylist.withWrongTypes().whereNot(
+            (map) => propertiesThatCanBeMissing.any((property) => map[property] == null) || map['songIds'] == []),
         validPlaylist.copyWith({'dateAdded': null, 'dateModified': null}),
-      ].assignUniqueIds(startId: validPlaylists.last.$1['id'] + 1);
+      ].assignUniqueIds(startId: validPlaylists.last.$2.id + 1);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
@@ -195,10 +202,12 @@ void main() {
           ..addAll(invalidPlaylists);
       });
       expect(
-        ContentControl.instance.state.playlists.sorted((item1, item2) => item1.id.compareTo(item2.id)),
-        validPlaylists.map((element) => element.$2).toList(),
+        ContentControl.instance.state.playlists
+            .sorted((item1, item2) => item1.id.compareTo(item2.id))
+            .map((playlist) => playlist.toMap()),
+        validPlaylists.map((element) => element.$2.toMap()),
       );
-      expect(crashlyticsObserver.nonFatalErrorCount, 446);
+      expect(crashlyticsObserver.nonFatalErrorCount, 389);
     });
 
     test('Handles invalid or incomplete songs', () async {
@@ -225,54 +234,55 @@ void main() {
         (validSong.copyWith({'id': 19}).copyWithout(['track']), songWith(id: 19, track: null)),
         (validSong.copyWith({'id': 20, 'dateAdded': -1}), songWith(id: 20, dateAdded: -1)),
         (validSong.copyWith({'id': 21, 'dateModified': -1}), songWith(id: 21, dateModified: -1)),
-        (validSong.copyWith({'id': 22, 'duration': -1}), songWith(id: 22, duration: -1)),
-        (validSong.copyWith({'id': 23, 'size': -1}), songWith(id: 23, size: -1)),
-        (validSong.copyWith({'id': 24, 'filesystemPath': ''}), songWith(id: 24, filesystemPath: '')),
-        (validSong.copyWith({'id': 25, 'filesystemPath': null}), songWith(id: 25, filesystemPath: null)),
-        (validSong.copyWith({'id': 26}).copyWithout(['filesystemPath']), songWith(id: 26, filesystemPath: null)),
+        (validSong.copyWith({'id': 22, 'dateModified': null}), songWith(id: 22, dateModified: songWith().dateAdded)),
         (
-          validSong.copyWith({'id': 27, 'isFavoriteInMediaStore': null}),
-          songWith(id: 27, isFavoriteInMediaStore: false),
+          validSong.copyWith({'id': 23}).copyWithout(['dateModified']),
+          songWith(id: 23, dateModified: songWith().dateAdded)
+        ),
+        (validSong.copyWith({'id': 24, 'duration': -1}), songWith(id: 24, duration: -1)),
+        (validSong.copyWith({'id': 25, 'size': -1}), songWith(id: 25, size: -1)),
+        (validSong.copyWith({'id': 26, 'size': null}), songWith(id: 26, size: null)),
+        (validSong.copyWith({'id': 27}).copyWithout(['size']), songWith(id: 27, size: null)),
+        (validSong.copyWith({'id': 28, 'filesystemPath': ''}), songWith(id: 28, filesystemPath: '')),
+        (validSong.copyWith({'id': 29, 'filesystemPath': null}), songWith(id: 29, filesystemPath: null)),
+        (validSong.copyWith({'id': 30}).copyWithout(['filesystemPath']), songWith(id: 30, filesystemPath: null)),
+        (
+          validSong.copyWith({'id': 31, 'isFavoriteInMediaStore': null}),
+          songWith(id: 31, isFavoriteInMediaStore: false)
         ),
         (
-          validSong.copyWith({'id': 28}).copyWithout(['isFavoriteInMediaStore']),
-          songWith(id: 28, isFavoriteInMediaStore: false),
+          validSong.copyWith({'id': 32}).copyWithout(['isFavoriteInMediaStore']),
+          songWith(id: 32, isFavoriteInMediaStore: false)
         ),
-        (validSong.copyWith({'id': 29, 'generationAdded': -1}), songWith(id: 29, generationAdded: -1)),
-        (validSong.copyWith({'id': 30, 'generationAdded': null}), songWith(id: 30, generationAdded: null)),
-        (validSong.copyWith({'id': 31}).copyWithout(['generationAdded']), songWith(id: 31, generationAdded: null)),
-        (validSong.copyWith({'id': 32, 'generationModified': -1}), songWith(id: 32, generationModified: -1)),
-        (validSong.copyWith({'id': 33, 'generationModified': null}), songWith(id: 33, generationModified: null)),
+        (validSong.copyWith({'id': 33, 'generationAdded': -1}), songWith(id: 33, generationAdded: -1)),
+        (validSong.copyWith({'id': 34, 'generationAdded': null}), songWith(id: 34, generationAdded: null)),
+        (validSong.copyWith({'id': 35}).copyWithout(['generationAdded']), songWith(id: 35, generationAdded: null)),
+        (validSong.copyWith({'id': 36, 'generationModified': -1}), songWith(id: 36, generationModified: -1)),
+        (validSong.copyWith({'id': 37, 'generationModified': null}), songWith(id: 37, generationModified: null)),
         (
-          validSong.copyWith({'id': 34}).copyWithout(['generationModified']),
-          songWith(id: 34, generationModified: null),
+          validSong.copyWith({'id': 38}).copyWithout(['generationModified']),
+          songWith(id: 38, generationModified: null)
         ),
       ];
+      final propertiesThatCanBeMissing = [
+        'album',
+        'albumId',
+        'genre',
+        'genreId',
+        'track',
+        'dateModified',
+        'size',
+        'filesystemPath',
+        'isFavoriteInMediaStore',
+        'generationAdded',
+        'generationModified',
+      ];
       final invalidSongs = [
-        ...validSong.copyWithout([
-          'album',
-          'albumId',
-          'genre',
-          'genreId',
-          'track',
-          'filesystemPath',
-          'isFavoriteInMediaStore',
-          'generationAdded',
-          'generationModified',
-        ]).subSets(),
-        ...validSong.withWrongTypes().whereNot(
-              (map) =>
-                  map['album'] == null ||
-                  map['albumId'] == null ||
-                  map['genre'] == null ||
-                  map['genreId'] == null ||
-                  map['track'] == null ||
-                  map['filesystemPath'] == null ||
-                  map['isFavoriteInMediaStore'] == null ||
-                  map['generationAdded'] == null ||
-                  map['generationModified'] == null,
-            ),
-      ].assignUniqueIds(startId: validSongs.last.$1['id'] + 1);
+        ...validSong.copyWithout(propertiesThatCanBeMissing).subSets(),
+        ...validSong
+            .withWrongTypes()
+            .whereNot((map) => propertiesThatCanBeMissing.any((property) => map[property] == null))
+      ].assignUniqueIds(startId: validSongs.last.$2.id + 1);
       late CrashlyticsObserver crashlyticsObserver;
       await setUpAppTest(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
@@ -280,10 +290,12 @@ void main() {
           ..addAll(invalidSongs);
       });
       expect(
-        ContentControl.instance.state.allSongs.songs.sorted((item1, item2) => item1.id.compareTo(item2.id)),
-        validSongs.map((element) => element.$2).toList(),
+        ContentControl.instance.state.allSongs.songs
+            .sorted((item1, item2) => item1.id.compareTo(item2.id))
+            .map((song) => song.toMap()),
+        validSongs.map((element) => element.$2.toMap()),
       );
-      expect(crashlyticsObserver.nonFatalErrorCount, 1334);
+      expect(crashlyticsObserver.nonFatalErrorCount, 1140);
     });
   });
 }

--- a/test/logic/models/content_test.dart
+++ b/test/logic/models/content_test.dart
@@ -9,17 +9,17 @@ extension _TestMap on Map<String, dynamic> {
   }
 
   Map<String, dynamic> copyWithout(List<String> keysToRemove) {
-    var map = Map.of(this);
+    final map = Map.of(this);
     keysToRemove.forEach(map.remove);
     return map;
   }
 
   Iterable<Map<String, dynamic>> subSets() sync* {
-    var subSets = [[]];
+    final subSets = [[]];
     yield {};
     for (final key in keys) {
-      for (var subSet in subSets.toList()) {
-        var newSubSet = subSet + [key];
+      for (final subSet in subSets.toList()) {
+        final newSubSet = subSet + [key];
         if (newSubSet.length >= keys.length) {
           continue;
         }
@@ -65,7 +65,7 @@ extension _TestMap on Map<String, dynamic> {
 
 extension _TestListMap on List<Map<String, dynamic>> {
   List<Map<String, dynamic>> assignUniqueIds({required int startId}) {
-    for (var element in this) {
+    for (final element in this) {
       if (element['id'] is int) {
         element['id'] = startId++;
       }

--- a/test/logic/models/content_test.dart
+++ b/test/logic/models/content_test.dart
@@ -111,18 +111,20 @@ void main() {
         ),
       ];
       late CrashlyticsObserver crashlyticsObserver;
-      await setUpAppTest(() {
+      registerAppSetup(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
         FakeSweyerPluginPlatform.instance.rawAlbums = validAlbums.map((element) => element.$1).toList();
       });
-      expect(
-        ContentControl.instance.state.albums.values
-            .sorted((item1, item2) => item1.id.compareTo(item2.id))
-            .map((album) => album.toMap()),
-        validAlbums.map((element) => element.$2.toMap()),
-        reason: "Should be able to correctly parse all valid albums",
-      );
-      expect(crashlyticsObserver.nonFatalErrorCount, 0, reason: "Should not reject any valid albums");
+      TestWidgetsFlutterBinding.ensureInitialized().runAppTestWithoutUi(() {
+        expect(
+          ContentControl.instance.state.albums.values
+              .sorted((item1, item2) => item1.id.compareTo(item2.id))
+              .map((album) => album.toMap()),
+          validAlbums.map((element) => element.$2.toMap()),
+          reason: "Should be able to correctly parse all valid albums",
+        );
+        expect(crashlyticsObserver.nonFatalErrorCount, 0, reason: "Should not reject any valid albums");
+      });
     });
 
     test('Handles valid artists', () async {
@@ -138,18 +140,20 @@ void main() {
         ),
       ];
       late CrashlyticsObserver crashlyticsObserver;
-      await setUpAppTest(() {
+      registerAppSetup(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
         FakeSweyerPluginPlatform.instance.rawArtists = validArtists.map((element) => element.$1).toList();
       });
-      expect(
-        ContentControl.instance.state.artists
-            .sorted((item1, item2) => item1.id.compareTo(item2.id))
-            .map((artist) => artist.toMap()),
-        validArtists.map((element) => element.$2.toMap()),
-        reason: "Should be able to correctly parse all valid artists",
-      );
-      expect(crashlyticsObserver.nonFatalErrorCount, 0, reason: "Should not reject any valid artists");
+      TestWidgetsFlutterBinding.ensureInitialized().runAppTestWithoutUi(() {
+        expect(
+          ContentControl.instance.state.artists
+              .sorted((item1, item2) => item1.id.compareTo(item2.id))
+              .map((artist) => artist.toMap()),
+          validArtists.map((element) => element.$2.toMap()),
+          reason: "Should be able to correctly parse all valid artists",
+        );
+        expect(crashlyticsObserver.nonFatalErrorCount, 0, reason: "Should not reject any valid artists");
+      });
     });
 
     test('Handles valid playlists', () async {
@@ -176,18 +180,20 @@ void main() {
         ),
       ];
       late CrashlyticsObserver crashlyticsObserver;
-      await setUpAppTest(() {
+      registerAppSetup(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
         FakeSweyerPluginPlatform.instance.rawPlaylists = validPlaylists.map((element) => element.$1).toList();
       });
-      expect(
-        ContentControl.instance.state.playlists
-            .sorted((item1, item2) => item1.id.compareTo(item2.id))
-            .map((playlist) => playlist.toMap()),
-        validPlaylists.map((element) => element.$2.toMap()),
-        reason: "Should be able to correctly parse all valid playlists",
-      );
-      expect(crashlyticsObserver.nonFatalErrorCount, 0, reason: "Should not reject any playlists");
+      TestWidgetsFlutterBinding.ensureInitialized().runAppTestWithoutUi(() {
+        expect(
+          ContentControl.instance.state.playlists
+              .sorted((item1, item2) => item1.id.compareTo(item2.id))
+              .map((playlist) => playlist.toMap()),
+          validPlaylists.map((element) => element.$2.toMap()),
+          reason: "Should be able to correctly parse all valid playlists",
+        );
+        expect(crashlyticsObserver.nonFatalErrorCount, 0, reason: "Should not reject any playlists");
+      });
     });
 
     test('Handles valid songs', () async {
@@ -245,18 +251,20 @@ void main() {
         ),
       ];
       late CrashlyticsObserver crashlyticsObserver;
-      await setUpAppTest(() {
+      registerAppSetup(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
         FakeSweyerPluginPlatform.instance.rawSongs = validSongs.map((element) => element.$1).toList();
       });
-      expect(
-        ContentControl.instance.state.allSongs.songs
-            .sorted((item1, item2) => item1.id.compareTo(item2.id))
-            .map((song) => song.toMap()),
-        validSongs.map((element) => element.$2.toMap()),
-        reason: "Should be able to correctly parse all valid songs",
-      );
-      expect(crashlyticsObserver.nonFatalErrorCount, 0, reason: "Should not reject any valid songs");
+      TestWidgetsFlutterBinding.ensureInitialized().runAppTestWithoutUi(() {
+        expect(
+          ContentControl.instance.state.allSongs.songs
+              .sorted((item1, item2) => item1.id.compareTo(item2.id))
+              .map((song) => song.toMap()),
+          validSongs.map((element) => element.$2.toMap()),
+          reason: "Should be able to correctly parse all valid songs",
+        );
+        expect(crashlyticsObserver.nonFatalErrorCount, 0, reason: "Should not reject any valid songs");
+      });
     });
   });
 
@@ -269,22 +277,24 @@ void main() {
         ...validAlbum.createVariantsWhereElementsHaveInvalidTypes(propertiesThatCanBeMissing),
       ].assignUniqueIds(startId: 0);
       late CrashlyticsObserver crashlyticsObserver;
-      await setUpAppTest(() {
+      registerAppSetup(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
         FakeSweyerPluginPlatform.instance.rawAlbums = invalidAlbums;
       });
-      expect(
-        ContentControl.instance.state.albums.values
-            .sorted((item1, item2) => item1.id.compareTo(item2.id))
-            .map((album) => album.toMap()),
-        [],
-        reason: "Should not accept any invalid albums",
-      );
-      expect(
-        crashlyticsObserver.nonFatalErrorCount,
-        invalidAlbums.length,
-        reason: "Should reject invalid albums and report non-fatal errors",
-      );
+      TestWidgetsFlutterBinding.ensureInitialized().runAppTestWithoutUi(() {
+        expect(
+          ContentControl.instance.state.albums.values
+              .sorted((item1, item2) => item1.id.compareTo(item2.id))
+              .map((album) => album.toMap()),
+          [],
+          reason: "Should not accept any invalid albums",
+        );
+        expect(
+          crashlyticsObserver.nonFatalErrorCount,
+          invalidAlbums.length,
+          reason: "Should reject invalid albums and report non-fatal errors",
+        );
+      });
     });
 
     test('Handles invalid or incomplete artists', () async {
@@ -295,22 +305,24 @@ void main() {
         ...validArtist.createVariantsWhereElementsHaveInvalidTypes(propertiesThatCanBeMissing),
       ].assignUniqueIds(startId: 0);
       late CrashlyticsObserver crashlyticsObserver;
-      await setUpAppTest(() {
+      registerAppSetup(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
         FakeSweyerPluginPlatform.instance.rawArtists = invalidArtists;
       });
-      expect(
-        ContentControl.instance.state.artists
-            .sorted((item1, item2) => item1.id.compareTo(item2.id))
-            .map((artist) => artist.toMap()),
-        [],
-        reason: "Should not accept any invalid artists",
-      );
-      expect(
-        crashlyticsObserver.nonFatalErrorCount,
-        invalidArtists.length,
-        reason: "Should reject invalid artists and report non-fatal errors",
-      );
+      TestWidgetsFlutterBinding.ensureInitialized().runAppTestWithoutUi(() {
+        expect(
+          ContentControl.instance.state.artists
+              .sorted((item1, item2) => item1.id.compareTo(item2.id))
+              .map((artist) => artist.toMap()),
+          [],
+          reason: "Should not accept any invalid artists",
+        );
+        expect(
+          crashlyticsObserver.nonFatalErrorCount,
+          invalidArtists.length,
+          reason: "Should reject invalid artists and report non-fatal errors",
+        );
+      });
     });
 
     test('Handles invalid or incomplete playlists', () async {
@@ -323,22 +335,24 @@ void main() {
             .whereNot((map) => map['songIds'] == []),
       ].assignUniqueIds(startId: 0);
       late CrashlyticsObserver crashlyticsObserver;
-      await setUpAppTest(() {
+      registerAppSetup(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
         FakeSweyerPluginPlatform.instance.rawPlaylists = invalidPlaylists;
       });
-      expect(
-        ContentControl.instance.state.playlists
-            .sorted((item1, item2) => item1.id.compareTo(item2.id))
-            .map((playlist) => playlist.toMap()),
-        [],
-        reason: "Should not accept any invalid playlists",
-      );
-      expect(
-        crashlyticsObserver.nonFatalErrorCount,
-        invalidPlaylists.length,
-        reason: "Should reject invalid playlists and report non-fatal errors",
-      );
+      TestWidgetsFlutterBinding.ensureInitialized().runAppTestWithoutUi(() {
+        expect(
+          ContentControl.instance.state.playlists
+              .sorted((item1, item2) => item1.id.compareTo(item2.id))
+              .map((playlist) => playlist.toMap()),
+          [],
+          reason: "Should not accept any invalid playlists",
+        );
+        expect(
+          crashlyticsObserver.nonFatalErrorCount,
+          invalidPlaylists.length,
+          reason: "Should reject invalid playlists and report non-fatal errors",
+        );
+      });
     });
 
     test('Handles invalid or incomplete songs', () async {
@@ -361,23 +375,25 @@ void main() {
         ...validSong.createVariantsWhereElementsHaveInvalidTypes(propertiesThatCanBeMissing),
       ].assignUniqueIds(startId: 0);
       late CrashlyticsObserver crashlyticsObserver;
-      await setUpAppTest(() {
+      registerAppSetup(() {
         crashlyticsObserver = CrashlyticsObserver(TestWidgetsFlutterBinding.ensureInitialized());
         FakeSweyerPluginPlatform.instance.rawSongs = invalidSongs;
       });
-      expect(
-        // The state is disposed if there is not songs, so use an empty list in that case.
-        (ContentControl.instance.stateNullable?.allSongs.songs ?? [])
-            .sorted((item1, item2) => item1.id.compareTo(item2.id))
-            .map((song) => song.toMap()),
-        [],
-        reason: "Should not accept any invalid songs",
-      );
-      expect(
-        crashlyticsObserver.nonFatalErrorCount,
-        invalidSongs.length,
-        reason: "Should reject invalid songs and report non-fatal errors",
-      );
+      TestWidgetsFlutterBinding.ensureInitialized().runAppTestWithoutUi(() {
+        expect(
+          // The state is disposed if there is not songs, so use an empty list in that case.
+          (ContentControl.instance.stateNullable?.allSongs.songs ?? [])
+              .sorted((item1, item2) => item1.id.compareTo(item2.id))
+              .map((song) => song.toMap()),
+          [],
+          reason: "Should not accept any invalid songs",
+        );
+        expect(
+          crashlyticsObserver.nonFatalErrorCount,
+          invalidSongs.length,
+          reason: "Should reject invalid songs and report non-fatal errors",
+        );
+      });
     });
   });
 }

--- a/test/observer/crashlytics.dart
+++ b/test/observer/crashlytics.dart
@@ -1,0 +1,38 @@
+import 'package:firebase_crashlytics_platform_interface/firebase_crashlytics_platform_interface.dart';
+
+import '../test.dart';
+
+/// An observer for crashlytics messages.
+class CrashlyticsObserver {
+  /// Whether to throw fatal errors.
+  final bool throwFatalErrors;
+
+  /// The number of reported non-fatal errors.
+  int get nonFatalErrorCount => _nonFatalErrorCount;
+  int _nonFatalErrorCount = 0;
+
+  /// The number of reported fatal errors.
+  int get fatalErrorCount => _fatalErrorCount;
+  int _fatalErrorCount = 0;
+
+  /// The number of reported errors.
+  int get errorCount => _fatalErrorCount + _nonFatalErrorCount;
+
+  /// Create a new crashlytics observer, which automatically
+  /// unregisters any previously created observer.
+  CrashlyticsObserver(TestWidgetsFlutterBinding binding, {this.throwFatalErrors = true}) {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(MethodChannelFirebaseCrashlytics.channel, (call) {
+      if (call.method == 'Crashlytics#recordError') {
+        if (call.arguments['fatal']) {
+          _fatalErrorCount++;
+          if (throwFatalErrors) {
+            throw call.arguments['exception'];
+          }
+        } else {
+          _nonFatalErrorCount++;
+        }
+      }
+      return null; // Ignore unimplemented method calls.
+    });
+  }
+}

--- a/test/observer/observer.dart
+++ b/test/observer/observer.dart
@@ -1,3 +1,4 @@
+export 'crashlytics.dart';
 export 'permissions.dart';
 export 'system.dart';
 export 'toast.dart';

--- a/test/test.dart
+++ b/test/test.dart
@@ -151,6 +151,7 @@ extension AppInitExtension on TestWidgetsFlutterBinding {
     JustAudioPlatform.instance = MockJustAudio(this);
     PackageInfoPlatform.instance = MethodChannelPackageInfo();
     PlayerInterfaceColorStyleControl.instance = PlayerInterfaceColorStyleControl();
+    await FakeFirebaseApp.install(this);
     defaultBinaryMessenger.setMockMethodCallHandler(const MethodChannel('dev.fluttercommunity.plus/package_info'),
         (MethodCall methodCall) async {
       return {


### PR DESCRIPTION
*This includes #145 and is based on top of #148.*

This makes content scanning more robust and prevents failing the entire content search because one item fails by catching exceptions on an item level and reporting them, which implements the first checkbox on #127.

I think it is valuable to report these as non-fatal errors, so we can see if we are too strict and need to make a content attribute nullable.