### PR TITLE
Accept null for more content fields

### DIFF
--- a/lib/logic/models/album.dart
+++ b/lib/logic/models/album.dart
@@ -102,7 +102,7 @@ class Album extends PersistentQueue implements PlatformAlbum {
       artistId: map['artistId'] as int?,
       firstYear: map['firstYear'] as int?,
       lastYear: map['lastYear'] as int?,
-      numberOfSongs: map['numberOfSongs'] as int,
+      numberOfSongs: map['numberOfSongs'] as int? ?? 0,
     );
   }
 

--- a/lib/logic/models/genre.dart
+++ b/lib/logic/models/genre.dart
@@ -30,7 +30,7 @@ class Genre extends Content implements PlatformGenre {
     return Genre(
       id: map['id'] as int,
       name: map['name'] as String,
-      songIds: map['songIds'].cast<int>(),
+      songIds: (map['songIds'] as List?)?.cast<int>() ?? [],
     );
   }
 

--- a/lib/logic/models/playlist.dart
+++ b/lib/logic/models/playlist.dart
@@ -5,7 +5,7 @@ import 'package:sweyer_plugin/sweyer_plugin.dart';
 class Playlist extends PersistentQueue with DuplicatingSongOriginMixin implements PlatformPlaylist {
   @override
   ContentType get type => ContentType.playlist;
-  final String filesystemPath;
+  final String? filesystemPath;
   final int dateAdded;
   final int dateModified;
   final String name;
@@ -111,11 +111,11 @@ class Playlist extends PersistentQueue with DuplicatingSongOriginMixin implement
     int dateAdded = map['dateAdded'] as int;
     return Playlist(
       id: map['id'] as int,
-      filesystemPath: map['filesystemPath'] as String,
+      filesystemPath: map['filesystemPath'] as String?,
       dateAdded: dateAdded,
       dateModified: map['dateModified'] as int? ?? dateAdded,
       name: map['name'] as String,
-      songIds: (map['songIds'] as List).cast<int>().toList(),
+      songIds: (map['songIds'] as List?)?.cast<int>().toList() ?? [],
     );
   }
 
@@ -134,7 +134,7 @@ class Playlist extends PersistentQueue with DuplicatingSongOriginMixin implement
 abstract class PlaylistCopyWith {
   Playlist call({
     int id,
-    String fileSystemPath,
+    String? fileSystemPath,
     int dateAdded,
     int dateModified,
     String name,
@@ -155,7 +155,7 @@ class _PlaylistCopyWith extends PlaylistCopyWith {
   @override
   Playlist call({
     Object id = _undefined,
-    Object fileSystemPath = _undefined,
+    Object? fileSystemPath = _undefined,
     Object dateAdded = _undefined,
     Object dateModified = _undefined,
     Object name = _undefined,
@@ -163,7 +163,7 @@ class _PlaylistCopyWith extends PlaylistCopyWith {
   }) {
     return Playlist(
       id: id == _undefined ? value.id : id as int,
-      filesystemPath: fileSystemPath == _undefined ? value.filesystemPath : fileSystemPath as String,
+      filesystemPath: fileSystemPath == _undefined ? value.filesystemPath : fileSystemPath as String?,
       dateAdded: dateAdded == _undefined ? value.dateAdded : dateAdded as int,
       dateModified: dateModified == _undefined ? value.dateModified : dateModified as int,
       name: name == _undefined ? value.name : name as String,

--- a/lib/logic/models/song.dart
+++ b/lib/logic/models/song.dart
@@ -39,7 +39,7 @@ class Song extends Content implements PlatformSong {
 
   /// Duration in milliseconds
   final int duration;
-  final int size;
+  final int? size;
   @override
   final String? filesystemPath;
 
@@ -150,6 +150,7 @@ class Song extends Content implements PlatformSong {
   }
 
   factory Song.fromMap(Map<String, dynamic> map) {
+    final dateAdded = map['dateAdded'] as int;
     return Song(
       id: map['id'] as int,
       album: map['album'] as String?,
@@ -160,10 +161,10 @@ class Song extends Content implements PlatformSong {
       genreId: map['genreId'] as int?,
       title: map['title'] as String,
       track: map['track'] as String?,
-      dateAdded: map['dateAdded'] as int,
-      dateModified: map['dateModified'] as int,
+      dateAdded: dateAdded,
+      dateModified: map['dateModified'] as int? ?? dateAdded,
       duration: map['duration'] as int,
-      size: map['size'] as int,
+      size: map['size'] as int?,
       filesystemPath: map['filesystemPath'] as String?,
       isFavoriteInMediaStore: map['isFavoriteInMediaStore'] as bool?,
       generationAdded: map['generationAdded'] as int?,
@@ -220,7 +221,7 @@ abstract class SongCopyWith {
     int dateAdded,
     int dateModified,
     int duration,
-    int size,
+    int? size,
     String? filesystemPath,
     bool? isFavoriteInMediaStore,
     int? generationAdded,
@@ -254,7 +255,7 @@ class _SongCopyWith extends SongCopyWith {
     Object dateAdded = _undefined,
     Object dateModified = _undefined,
     Object duration = _undefined,
-    Object size = _undefined,
+    Object? size = _undefined,
     Object? filesystemPath = _undefined,
     Object? isFavoriteInMediaStore = _undefined,
     Object? generationAdded = _undefined,
@@ -275,7 +276,7 @@ class _SongCopyWith extends SongCopyWith {
       dateAdded: dateAdded == _undefined ? value.dateAdded : dateAdded as int,
       dateModified: dateModified == _undefined ? value.dateModified : dateModified as int,
       duration: duration == _undefined ? value.duration : duration as int,
-      size: size == _undefined ? value.size : size as int,
+      size: size == _undefined ? value.size : size as int?,
       filesystemPath: filesystemPath == _undefined ? value.filesystemPath : filesystemPath as String?,
       isFavoriteInMediaStore:
           isFavoriteInMediaStore == _undefined ? value.isFavoriteInMediaStore : isFavoriteInMediaStore as bool?,


### PR DESCRIPTION
Similar to #145, but for other fields where we can handle null in a simple way.
This makes the content scanning more robust and hopefully prevents errors like the one linked in #145.

Woks towards the third checkmark on #127.