### PR TITLE
Update all GitHub actions dependencies

### DIFF
--- a/.github/workflows/deploy_google_play/action.yml
+++ b/.github/workflows/deploy_google_play/action.yml
@@ -67,7 +67,7 @@ runs:
         mv key.properties ${{ github.workspace }}/android/key.properties
 
     - name: 📖 Read app version
-      uses: NiklasLehnfeld/flutter-version-number-action@main
+      uses: NiklasLehnfeld/flutter-version-number-action@v1
       id: read-version
       with:
         file-path: pubspec.yaml

--- a/.github/workflows/deploy_google_play/action.yml
+++ b/.github/workflows/deploy_google_play/action.yml
@@ -106,21 +106,21 @@ runs:
         zip -r ${{ github.workspace }}/symbols.zip ${{ github.workspace }}/build/app/outputs/symbols/
 
     - name: 📁 Upload build artifacts (symbols)
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: symbols
         path: |
           ${{ github.workspace }}/symbols.zip
 
     - name: 📁 Upload build artifacts (aab)
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: sweyer@${{ steps.read-version.outputs.version-number }}.aab
         path: |
           ${{ github.workspace }}/build/app/outputs/bundle/release/sweyer@${{ steps.read-version.outputs.version-number }}.aab
 
     - name: 📁 Upload build artifacts (apk)
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: sweyer@${{ steps.read-version.outputs.version-number }}.apk
         path: |

--- a/.github/workflows/sweyer_release.yml
+++ b/.github/workflows/sweyer_release.yml
@@ -24,6 +24,8 @@ jobs:
       - name: ☂ Upload Code Coverage
         if: ${{ github.event.inputs.skip-tests == 'false' }}
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: 🚀🤖 Bundle and deploy to Google Play
         uses: ./.github/workflows/deploy_google_play

--- a/.github/workflows/sweyer_release.yml
+++ b/.github/workflows/sweyer_release.yml
@@ -13,7 +13,7 @@ jobs:
     environment: prod
     steps:
       - name: 📚 Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 🧪 Test Sweyer
         if: ${{ github.event.inputs.skip-tests == 'false' }}
@@ -23,7 +23,7 @@ jobs:
 
       - name: ☂ Upload Code Coverage
         if: ${{ github.event.inputs.skip-tests == 'false' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
 
       - name: 🚀🤖 Bundle and deploy to Google Play
         uses: ./.github/workflows/deploy_google_play

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,3 +21,5 @@ jobs:
 
       - name: ☂ Upload Code Coverage
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📚 Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 🧪 Test Sweyer
         uses: ./.github/workflows/test
@@ -20,4 +20,4 @@ jobs:
           testing_arguments: --coverage
 
       - name: ☂ Upload Code Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4

--- a/.github/workflows/update_goldens.yml
+++ b/.github/workflows/update_goldens.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: 📚 Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 🧪 Test Sweyer
         uses: ./.github/workflows/test
@@ -23,13 +23,13 @@ jobs:
           testing_arguments: --update-goldens
 
       - name: 📁 Save updated Golden test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: golden-test-updated
           path: test/golden/goldens
 
       - name: 💾 Commit updated Golden test artifacts
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         if: github.event.inputs.commit == 'true'
         with:
           commit_message: 🤖 Update Golden test artifacts 🤖


### PR DESCRIPTION
This updates our CI dependencies. I read through the change logs and made sure that there are no breaking changes for us.

There is one exception:

`codecov/codecov-action@v4` removes tokenless uploads of coverage information. This means that we need to make sure that we have [configured our Codecov token in the GitHub repository settings as described in the documentation](https://docs.codecov.com/docs/adding-the-codecov-token#github-actions). I don't have access to these settings so only you can do that.

Hopefully the update will fix the Codecov upload failures we've seen on recent CI runs like [here](https://github.com/nt4f04uNd/sweyer/actions/runs/10121497714/job/27992507895#step:4:33).