### PR TITLE
Allow playlist modification date to be nullable

### DIFF
--- a/lib/logic/models/playlist.dart
+++ b/lib/logic/models/playlist.dart
@@ -7,7 +7,7 @@ class Playlist extends PersistentQueue with DuplicatingSongOriginMixin implement
   ContentType get type => ContentType.playlist;
   final String? filesystemPath;
   final int dateAdded;
-  final int dateModified;
+  final int? dateModified;
   final String name;
   @override
   final List<int> songIds;
@@ -108,12 +108,11 @@ class Playlist extends PersistentQueue with DuplicatingSongOriginMixin implement
   }
 
   factory Playlist.fromMap(Map<String, dynamic> map) {
-    int dateAdded = map['dateAdded'] as int;
     return Playlist(
       id: map['id'] as int,
       filesystemPath: map['filesystemPath'] as String?,
-      dateAdded: dateAdded,
-      dateModified: map['dateModified'] as int? ?? dateAdded,
+      dateAdded: map['dateAdded'] as int,
+      dateModified: map['dateModified'] as int?,
       name: map['name'] as String,
       songIds: (map['songIds'] as List?)?.cast<int>().toList() ?? [],
     );
@@ -136,7 +135,7 @@ abstract class PlaylistCopyWith {
     int id,
     String? fileSystemPath,
     int dateAdded,
-    int dateModified,
+    int? dateModified,
     String name,
     List<int> songIds,
   });
@@ -157,7 +156,7 @@ class _PlaylistCopyWith extends PlaylistCopyWith {
     Object id = _undefined,
     Object? fileSystemPath = _undefined,
     Object dateAdded = _undefined,
-    Object dateModified = _undefined,
+    Object? dateModified = _undefined,
     Object name = _undefined,
     Object songIds = _undefined,
   }) {
@@ -165,7 +164,7 @@ class _PlaylistCopyWith extends PlaylistCopyWith {
       id: id == _undefined ? value.id : id as int,
       filesystemPath: fileSystemPath == _undefined ? value.filesystemPath : fileSystemPath as String?,
       dateAdded: dateAdded == _undefined ? value.dateAdded : dateAdded as int,
-      dateModified: dateModified == _undefined ? value.dateModified : dateModified as int,
+      dateModified: dateModified == _undefined ? value.dateModified : dateModified as int?,
       name: name == _undefined ? value.name : name as String,
       songIds: songIds == _undefined ? value.songIds : songIds as List<int>,
     );

--- a/lib/logic/models/sort.dart
+++ b/lib/logic/models/sort.dart
@@ -363,7 +363,7 @@ class PlaylistSort extends Sort<Playlist> {
   }
 
   int _fallbackDateModified(Playlist a, Playlist b) {
-    return a.dateModified.compareTo(b.dateModified);
+    return a.dateModified.compareToNullable(b.dateModified, nullCompareResult: order == SortOrder.descending ? 1 : -1);
   }
 
   @override
@@ -372,7 +372,8 @@ class PlaylistSort extends Sort<Playlist> {
     switch (feature) {
       case PlaylistSortFeature.dateModified:
         c = (a, b) {
-          final compare = a.dateModified.compareTo(b.dateModified);
+          final compare = a.dateModified
+              .compareToNullable(b.dateModified, nullCompareResult: order == SortOrder.descending ? 1 : -1);
           if (compare == 0) {
             return _fallbackName(a, b);
           }

--- a/lib/utils/compare.dart
+++ b/lib/utils/compare.dart
@@ -1,0 +1,21 @@
+extension NullableCompare<T extends Comparable<Comparable<T>>> on Comparable<T>? {
+  int compareToNullable(T? other, {nullCompareResult = -1}) {
+    final self = this;
+    if (self != null) {
+      return self.compareToNullable(other, nullCompareResult: nullCompareResult);
+    }
+    if (other != null) {
+      return -other.compareToNullable(self, nullCompareResult: nullCompareResult);
+    }
+    return 0;
+  }
+}
+
+extension CompareNullable<T> on Comparable<T> {
+  int compareToNullable(T? other, {nullCompareResult = -1}) {
+    if (other != null) {
+      return compareTo(other);
+    }
+    return nullCompareResult;
+  }
+}

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,5 +1,6 @@
 export 'color.dart';
 export 'context.dart';
+export 'compare.dart';
 export 'line_height.dart';
 export 'measure.dart';
 export 'memoize.dart';

--- a/test/logic/models/sort_test.dart
+++ b/test/logic/models/sort_test.dart
@@ -356,10 +356,8 @@ void main() {
       for (final MapEntry(key: feature, value: expectedContentList) in featureTestCases.entries) {
         test('Sorts songs by ${feature.name} ${sortOrder.name}', () async {
           expect(
-            (songs.toList()..sort(SongSort(feature: feature, order: sortOrder).comparator))
-                .map((song) => song.toMap())
-                .toList(),
-            expectedContentList.map((song) => song.toMap()).toList(),
+            (songs.toList()..sort(SongSort(feature: feature, order: sortOrder).comparator)).map((song) => song.toMap()),
+            expectedContentList.map((song) => song.toMap()),
           );
         });
       }
@@ -624,9 +622,8 @@ void main() {
         test('Sorts albums by ${feature.name} ${sortOrder.name}', () async {
           expect(
             (albums.toList()..sort(AlbumSort(feature: feature, order: sortOrder).comparator))
-                .map((album) => album.toMap())
-                .toList(),
-            expectedContentList.map((album) => album.toMap()).toList(),
+                .map((album) => album.toMap()),
+            expectedContentList.map((album) => album.toMap()),
           );
         });
       }
@@ -648,8 +645,9 @@ void main() {
         playlistWith(id: 8, name: 'я (кириллица)', dateModified: 0, dateAdded: 0),
         playlistWith(id: 9, name: '', dateModified: 1, dateAdded: 0),
         playlistWith(id: 10, name: '', dateModified: -1, dateAdded: 0),
-        playlistWith(id: 11, name: '', dateModified: 0, dateAdded: 1),
-        playlistWith(id: 12, name: '', dateModified: 0, dateAdded: -1),
+        playlistWith(id: 11, name: '', dateModified: null, dateAdded: 0),
+        playlistWith(id: 12, name: '', dateModified: 0, dateAdded: 1),
+        playlistWith(id: 13, name: '', dateModified: 0, dateAdded: -1),
       ];
     });
     final Map<SortOrder, Map<PlaylistSortFeature, List<Playlist>>> testCases = {
@@ -657,8 +655,8 @@ void main() {
         PlaylistSortFeature.dateModified: [
           playlistWith(id: 10, name: '', dateModified: -1, dateAdded: 0),
           playlistWith(id: 0, name: '', dateModified: 0, dateAdded: 0),
-          playlistWith(id: 11, name: '', dateModified: 0, dateAdded: 1),
-          playlistWith(id: 12, name: '', dateModified: 0, dateAdded: -1),
+          playlistWith(id: 12, name: '', dateModified: 0, dateAdded: 1),
+          playlistWith(id: 13, name: '', dateModified: 0, dateAdded: -1),
           playlistWith(id: 1, name: 'A', dateModified: 0, dateAdded: 0),
           playlistWith(id: 3, name: 'a', dateModified: 0, dateAdded: 0),
           playlistWith(id: 2, name: 'AA', dateModified: 0, dateAdded: 0),
@@ -668,12 +666,14 @@ void main() {
           playlistWith(id: 6, name: 'АА (кириллица)', dateModified: 0, dateAdded: 0),
           playlistWith(id: 8, name: 'я (кириллица)', dateModified: 0, dateAdded: 0),
           playlistWith(id: 9, name: '', dateModified: 1, dateAdded: 0),
+          playlistWith(id: 11, name: '', dateModified: null, dateAdded: 0),
         ],
         PlaylistSortFeature.dateAdded: [
-          playlistWith(id: 12, name: '', dateModified: 0, dateAdded: -1),
+          playlistWith(id: 13, name: '', dateModified: 0, dateAdded: -1),
           playlistWith(id: 0, name: '', dateModified: 0, dateAdded: 0),
           playlistWith(id: 9, name: '', dateModified: 1, dateAdded: 0),
           playlistWith(id: 10, name: '', dateModified: -1, dateAdded: 0),
+          playlistWith(id: 11, name: '', dateModified: null, dateAdded: 0),
           playlistWith(id: 1, name: 'A', dateModified: 0, dateAdded: 0),
           playlistWith(id: 3, name: 'a', dateModified: 0, dateAdded: 0),
           playlistWith(id: 2, name: 'AA', dateModified: 0, dateAdded: 0),
@@ -682,14 +682,15 @@ void main() {
           playlistWith(id: 7, name: 'а (кириллица)', dateModified: 0, dateAdded: 0),
           playlistWith(id: 6, name: 'АА (кириллица)', dateModified: 0, dateAdded: 0),
           playlistWith(id: 8, name: 'я (кириллица)', dateModified: 0, dateAdded: 0),
-          playlistWith(id: 11, name: '', dateModified: 0, dateAdded: 1),
+          playlistWith(id: 12, name: '', dateModified: 0, dateAdded: 1),
         ],
         PlaylistSortFeature.name: [
           playlistWith(id: 10, name: '', dateModified: -1, dateAdded: 0),
           playlistWith(id: 0, name: '', dateModified: 0, dateAdded: 0),
-          playlistWith(id: 11, name: '', dateModified: 0, dateAdded: 1),
-          playlistWith(id: 12, name: '', dateModified: 0, dateAdded: -1),
+          playlistWith(id: 12, name: '', dateModified: 0, dateAdded: 1),
+          playlistWith(id: 13, name: '', dateModified: 0, dateAdded: -1),
           playlistWith(id: 9, name: '', dateModified: 1, dateAdded: 0),
+          playlistWith(id: 11, name: '', dateModified: null, dateAdded: 0),
           playlistWith(id: 1, name: 'A', dateModified: 0, dateAdded: 0),
           playlistWith(id: 3, name: 'a', dateModified: 0, dateAdded: 0),
           playlistWith(id: 2, name: 'AA', dateModified: 0, dateAdded: 0),
@@ -712,12 +713,13 @@ void main() {
           playlistWith(id: 1, name: 'A', dateModified: 0, dateAdded: 0),
           playlistWith(id: 3, name: 'a', dateModified: 0, dateAdded: 0),
           playlistWith(id: 0, name: '', dateModified: 0, dateAdded: 0),
-          playlistWith(id: 11, name: '', dateModified: 0, dateAdded: 1),
-          playlistWith(id: 12, name: '', dateModified: 0, dateAdded: -1),
+          playlistWith(id: 12, name: '', dateModified: 0, dateAdded: 1),
+          playlistWith(id: 13, name: '', dateModified: 0, dateAdded: -1),
           playlistWith(id: 10, name: '', dateModified: -1, dateAdded: 0),
+          playlistWith(id: 11, name: '', dateModified: null, dateAdded: 0),
         ],
         PlaylistSortFeature.dateAdded: [
-          playlistWith(id: 11, name: '', dateModified: 0, dateAdded: 1),
+          playlistWith(id: 12, name: '', dateModified: 0, dateAdded: 1),
           playlistWith(id: 8, name: 'я (кириллица)', dateModified: 0, dateAdded: 0),
           playlistWith(id: 6, name: 'АА (кириллица)', dateModified: 0, dateAdded: 0),
           playlistWith(id: 5, name: 'А (кириллица)', dateModified: 0, dateAdded: 0),
@@ -729,7 +731,8 @@ void main() {
           playlistWith(id: 0, name: '', dateModified: 0, dateAdded: 0),
           playlistWith(id: 9, name: '', dateModified: 1, dateAdded: 0),
           playlistWith(id: 10, name: '', dateModified: -1, dateAdded: 0),
-          playlistWith(id: 12, name: '', dateModified: 0, dateAdded: -1),
+          playlistWith(id: 11, name: '', dateModified: null, dateAdded: 0),
+          playlistWith(id: 13, name: '', dateModified: 0, dateAdded: -1),
         ],
         PlaylistSortFeature.name: [
           playlistWith(id: 8, name: 'я (кириллица)', dateModified: 0, dateAdded: 0),
@@ -742,9 +745,10 @@ void main() {
           playlistWith(id: 3, name: 'a', dateModified: 0, dateAdded: 0),
           playlistWith(id: 9, name: '', dateModified: 1, dateAdded: 0),
           playlistWith(id: 0, name: '', dateModified: 0, dateAdded: 0),
-          playlistWith(id: 11, name: '', dateModified: 0, dateAdded: 1),
-          playlistWith(id: 12, name: '', dateModified: 0, dateAdded: -1),
+          playlistWith(id: 12, name: '', dateModified: 0, dateAdded: 1),
+          playlistWith(id: 13, name: '', dateModified: 0, dateAdded: -1),
           playlistWith(id: 10, name: '', dateModified: -1, dateAdded: 0),
+          playlistWith(id: 11, name: '', dateModified: null, dateAdded: 0),
         ],
       },
     };
@@ -753,9 +757,8 @@ void main() {
         test('Sorts playlists by ${feature.name} ${sortOrder.name}', () async {
           expect(
             (playlists.toList()..sort(PlaylistSort(feature: feature, order: sortOrder).comparator))
-                .map((playlist) => playlist.toMap())
-                .toList(),
-            expectedContentList.map((playlist) => playlist.toMap()).toList(),
+                .map((playlist) => playlist.toMap()),
+            expectedContentList.map((playlist) => playlist.toMap()),
           );
         });
       }
@@ -882,9 +885,8 @@ void main() {
         test('Sorts artists by ${feature.name} ${sortOrder.name}', () async {
           expect(
             (artists.toList()..sort(ArtistSort(feature: feature, order: sortOrder).comparator))
-                .map((artist) => artist.toMap())
-                .toList(),
-            expectedContentList.map((artist) => artist.toMap()).toList(),
+                .map((artist) => artist.toMap()),
+            expectedContentList.map((artist) => artist.toMap()),
           );
         });
       }


### PR DESCRIPTION
Instead of falling back to the `dateAdded`, we now just allow the modification date of a playlist to be null. This is only really relevant during sorting, where we sort playlists with a null modification date towards the end (regardless whether we sort ascending or descending) (as discussed in https://github.com/nt4f04uNd/sweyer/pull/152#discussion_r1730453903). Fixes #157.