### PR TITLE
Simplify the Gemfile so dependabot can parse it correctly

### DIFF
--- a/android/Gemfile
+++ b/android/Gemfile
@@ -2,5 +2,4 @@ source "https://rubygems.org"
 
 gem "fastlane"
 
-plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval_gemfile(plugins_path) if File.exist?(plugins_path)
+eval_gemfile("fastlane/Pluginfile") if File.exist?("fastlane/Pluginfile")


### PR DESCRIPTION
Unfortunately dependabot failed to parse the `/androif/Gemfile`, which was added in #179.

![Dependabot error](https://github.com/user-attachments/assets/b915ef84-fa20-4583-8c59-b54e7870f1e9)

This approach should not change the behaviour of the Gemfile, and seems to work for https://github.com/WFCD/navis/blob/master/android/Gemfile.