### PR TITLE
Update to Flutter 3.29.2

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,4 +1,4 @@
 {
-  "flutter": "3.22.2",
+  "flutter": "3.29.2",
   "flavors": {}
 }

--- a/.github/workflows/build_executables.yml
+++ b/.github/workflows/build_executables.yml
@@ -17,7 +17,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.22.2
+          flutter-version: 3.29.2
           channel: stable
           cache: true
 

--- a/.github/workflows/deploy_google_play/action.yml
+++ b/.github/workflows/deploy_google_play/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: The channel of the Flutter used to build Sweyer with. 
   flutter_version:
     required: false
-    default: "3.22.2"
+    default: "3.29.2"
     description: The version of Flutter used to build Sweyer with.
   ruby_version:
     required: false

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: The channel of the Flutter used to build Sweyer with. 
   flutter_version:
     required: false
-    default: "3.22.2"
+    default: "3.29.2"
     description: The version of Flutter used to build Sweyer with.
   testing_arguments:
     required: false

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -41,8 +41,12 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/android/app/src/main/kotlin/com/nt4f04und/sweyer/MusicPlayerAppWidget.kt
+++ b/android/app/src/main/kotlin/com/nt4f04und/sweyer/MusicPlayerAppWidget.kt
@@ -160,7 +160,7 @@ class MusicPlayerAppWidget : HomeWidgetProvider() {
             matrix,
             true
         )
-        val imageRounded = Bitmap.createBitmap(size.width, size.height, bitmap.config)
+        val imageRounded = Bitmap.createBitmap(size.width, size.height, bitmap.config!!)
         val canvas = Canvas(imageRounded)
         val paint = Paint()
         paint.isAntiAlias = true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,12 +18,12 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
+    id "com.android.application" version '8.3.2' apply false
     // START: FlutterFire Configuration
     id "com.google.gms.google-services" version "4.3.15" apply false
     id "com.google.firebase.crashlytics" version "2.8.1" apply false
     // END: FlutterFire Configuration
-    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+    id "org.jetbrains.kotlin.android" version "2.0.20" apply false
 }
 
 include ":app"

--- a/lib/localization/arb/intl_de.arb
+++ b/lib/localization/arb/intl_de.arb
@@ -26,7 +26,9 @@
   "tracksPlural": "{count, plural, =1{{count} Lied} other{{count} Lieder}}",
   "@tracksPlural": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "album": "Album",
@@ -44,7 +46,9 @@
   "albumsPlural": "{count, plural, =1{{count} Album} other{{count} Alben}}",
   "@albumsPlural": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "playlist": "Wiedergabeliste",
@@ -62,7 +66,9 @@
   "playlistsPlural": "{count, plural, =1{{count} Wiedergabeliste} other{{count} Wiedergabelisten}}",
   "@playlistsPlural": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "artist": "Künstler",
@@ -80,7 +86,9 @@
   "artistsPlural": "{count, plural, other{{count} Künstler}}",
   "@artistsPlural": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "albumNotFound": "Album nicht gefunden",
@@ -139,7 +147,9 @@
   "andNMore": "Und {count} weitere",
   "@andNMore": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     },
     "description": "Beispiel: 'Und 3 weitere'"
   },
@@ -153,13 +163,17 @@
   "removeTracks": "{count, plural, =1{Lied entfernen} other{{count} Lieder entfernen}}",
   "@removeTracks": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "removeTracksConfirmation": "{count, plural, =1{Bist du sicher, dass du {title} entfernen möchtest?} other{Bist du sicher, dass du die ausgewählten Lieder entfernen möchtest?}}",
   "@removeTracksConfirmation": {
     "placeholders": {
-      "count": {},
+      "count": {
+        "type": "num"
+      },
       "title": {
         "type": "String?",
         "example": "Lied Name"
@@ -171,13 +185,17 @@
   "deleteTracks": "{count, plural, =1{Lied löschen} other{{count} Lieder löschen}}",
   "@deleteTracks": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "deleteTracksConfirmation": "{count, plural, =1{Bist du sicher, dass du {title} löschen möchtest?} other{Bist du sicher, dass du die ausgewählten Lieder löschen möchtest?}}",
   "@deleteTracksConfirmation": {
     "placeholders": {
-      "count": {},
+      "count": {
+        "type": "num"
+      },
       "title": {
         "type": "String?",
         "example": "Liedname"
@@ -188,13 +206,17 @@
   "deletePlaylists": "{count, plural, =1{Wiedergabeliste löschen} other{{count} Wiedergabelisten löschen}}",
   "@deletePlaylists": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "deletePlaylistsConfirmation": "{count, plural, =1{Bist du sicher, dass du {title} löschen möchtest?} other{Bist du sicher, dass du die ausgewählten Wiedergabelisten löschen möchtest?}}",
   "@deletePlaylistsConfirmation": {
     "placeholders": {
-      "count": {},
+      "count": {
+        "type": "num"
+      },
       "title": {
         "type": "String?",
         "example": "Wiedergabelistenname"
@@ -271,7 +293,9 @@
   "onThePathToDevModeClicksRemaining": "{remainingClicks, plural, =1{Du bist fast da, nur noch 1 Klick verbleibend...} other{Du bist fast da, nur noch {remainingClicks} Klicks verbleibend...}}",
   "@onThePathToDevModeClicksRemaining": {
     "placeholders": {
-      "remainingClicks": {}
+      "remainingClicks": {
+        "type": "num"
+      }
     },
     "description": "Wird angezeigt, wenn der Nutzer dabei ist, ein Entwickler zu werden, Part 2"
   },

--- a/lib/localization/arb/intl_en.arb
+++ b/lib/localization/arb/intl_en.arb
@@ -26,7 +26,9 @@
   "tracksPlural": "{count, plural, =1{{count} track} other{{count} tracks}}",
   "@tracksPlural": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "album": "Album",
@@ -44,7 +46,9 @@
   "albumsPlural": "{count, plural, =1{{count} album} other{{count} albums}}",
   "@albumsPlural": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "playlist": "Playlist",
@@ -62,7 +66,9 @@
   "playlistsPlural": "{count, plural, =1{{count} playlist} other{{count} playlists}}",
   "@playlistsPlural": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "artist": "Artist",
@@ -80,7 +86,9 @@
   "artistsPlural": "{count, plural, =1{{count} artist} other{{count} artists}}",
   "@artistsPlural": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "albumNotFound": "Album not found",
@@ -139,7 +147,9 @@
   "andNMore": "And {count} more",
   "@andNMore": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     },
     "description": "'And 3 more'"
   },
@@ -153,13 +163,17 @@
   "removeTracks": "{count, plural, =1{Remove track} other{Remove {count} tracks}}",
   "@removeTracks": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "removeTracksConfirmation": "{count, plural, =1{Are you sure you want to remove {title}?} other{Are you sure you want to remove selected tracks?}}",
   "@removeTracksConfirmation": {
     "placeholders": {
-      "count": {},
+      "count": {
+        "type": "num"
+      },
       "title": {
         "type": "String?",
         "example": "Track Name"
@@ -171,13 +185,17 @@
   "deleteTracks": "{count, plural, =1{Delete track} other{Delete {count} tracks}}",
   "@deleteTracks": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "deleteTracksConfirmation": "{count, plural, =1{Are you sure you want to delete {title}?} other{Are you sure you want to delete selected tracks?}}",
   "@deleteTracksConfirmation": {
     "placeholders": {
-      "count": {},
+      "count": {
+        "type": "num"
+      },
       "title": {
         "type": "String?",
         "example": "Track Name"
@@ -188,13 +206,17 @@
   "deletePlaylists": "{count, plural, =1{Delete playlist} other{Delete {count} playlists}}",
   "@deletePlaylists": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "deletePlaylistsConfirmation": "{count, plural, =1{Are you sure you want to delete {title}?} other{Are you sure you want to delete selected playlists?}}",
   "@deletePlaylistsConfirmation": {
     "placeholders": {
-      "count": {},
+      "count": {
+        "type": "num"
+      },
       "title": {
         "type": "String?",
         "example": "Playlist Name"
@@ -271,7 +293,9 @@
   "onThePathToDevModeClicksRemaining": "{remainingClicks, plural, =1{You're almost there, only 1 click remaining...} other{You're almost there, only {remainingClicks} clicks remaining...}}",
   "@onThePathToDevModeClicksRemaining": {
     "placeholders": {
-      "remainingClicks": {}
+      "remainingClicks": {
+        "type": "num"
+      }
     },
     "description": "Shown when user is about to become a developer, part 2"
   },

--- a/lib/localization/arb/intl_ru.arb
+++ b/lib/localization/arb/intl_ru.arb
@@ -17,7 +17,9 @@
   "tracksPlural": "{count, plural, =0{{count} треков} =1{{count} трек} few{{count} трека} many{{count} треков} other{{count} трека}}",
   "@tracksPlural": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "album": "Альбом",
@@ -35,7 +37,9 @@
   "albumsPlural": "{count, plural, =0{{count} альбомов} =1{{count} альбом} few{{count} альбома} many{{count} альбомов} other{{count} альбома}}",
   "@albumsPlural": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "playlist": "Плейлист",
@@ -53,7 +57,9 @@
   "playlistsPlural": "{count, plural, =0{{count} плейлистов} =1{{count} плейлист} few{{count} плейлиста} many{{count} плейлистов} other{{count} плейлиста}}",
   "@playlistsPlural": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "artist": "Исполнитель",
@@ -71,7 +77,9 @@
   "artistsPlural": "{count, plural, =0{{count} исполнителей} =1{{count} исполнитель} few{{count} исполнителя} many{{count} исполнителей} other{{count} исполнителя}}",
   "@artistsPlural": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "albumNotFound": "Альбом не найден",
@@ -103,7 +111,9 @@
   "andNMore": "И еще {count}",
   "@andNMore": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "done": "Готово",
@@ -116,13 +126,17 @@
   "removeTracks": "{count, plural, =1{Убрать трек} few{Убрать {count} трека} many{Убрать {count} треков} other{Убрать {count} трека}}",
   "@removeTracks": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "removeTracksConfirmation": "{count, plural, =1{Вы точно хотите убрать {title}?} other{Вы точно хотите убрать выбранные треки?}}",
   "@removeTracksConfirmation": {
     "placeholders": {
-      "count": {},
+      "count": {
+        "type": "num"
+      },
       "title": {
         "type": "String?",
         "example": "Track Name"
@@ -134,13 +148,17 @@
   "deleteTracks": "{count, plural, =1{Удалить трек} few{Удалить {count} трека} many{Удалить {count} треков} other{Удалить {count} трека}}",
   "@deleteTracks": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "deleteTracksConfirmation": "{count, plural, =1{Вы точно хотите удалить {title}?} other{Вы точно хотите удалить выбранные треки?}}",
   "@deleteTracksConfirmation": {
     "placeholders": {
-      "count": {},
+      "count": {
+        "type": "num"
+      },
       "title": {
         "type": "String?",
         "example": "Track Name"
@@ -151,13 +169,17 @@
   "deletePlaylists": "{count, plural, =1{Удалить плейлист} few{Удалить {count} плейлиста} many{Удалить {count} плейлистов} other{Удалить {count} плейлиста}}",
   "@deletePlaylists": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "deletePlaylistsConfirmation": "{count, plural, =1{Вы точно хотите удалить {title}?} other{Вы точно хотите удалить выбранные плейлисты?}}",
   "@deletePlaylistsConfirmation": {
     "placeholders": {
-      "count": {},
+      "count": {
+        "type": "num"
+      },
       "title": {
         "type": "String?",
         "example": "Playlist Name"
@@ -222,7 +244,9 @@
   "onThePathToDevModeClicksRemaining": "{remainingClicks, plural, =1{Вы почти у цели, остался всего 1 клик...} few{Вы почти у цели, осталось всего {remainingClicks} клика...} many{Вы почти у цели, осталось всего {remainingClicks} кликов...} other{Вы почти у цели, осталось всего {remainingClicks} клика...}}",
   "@onThePathToDevModeClicksRemaining": {
     "placeholders": {
-      "remainingClicks": {}
+      "remainingClicks": {
+        "type": "num"
+      }
     }
   },
   "devTestToast": "Тестовый тост",

--- a/lib/localization/arb/intl_tr.arb
+++ b/lib/localization/arb/intl_tr.arb
@@ -26,7 +26,9 @@
   "tracksPlural": "{count, plural, =1{{count} parça} other{{count} adet parça}}",
   "@tracksPlural": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "album": "Albüm",
@@ -44,7 +46,9 @@
   "albumsPlural": "{count, plural, =1{{count} albüm} other{{count} adet albüm}}",
   "@albumsPlural": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "playlist": "Oynatma listesi",
@@ -62,7 +66,9 @@
   "playlistsPlural": "{count, plural, =1{{count} oynatma listesj} other{{count} adet oynatma listesi}}",
   "@playlistsPlural": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "artist": "Sanatçı",
@@ -80,7 +86,9 @@
   "artistsPlural": "{count, plural, =1{{count} sanatçı} other{{count} adet sanatçı}}",
   "@artistsPlural": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "albumNotFound": "Albüm bulunamadı",
@@ -139,7 +147,9 @@
   "andNMore": "Ve {count} tane daha",
   "@andNMore": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     },
     "description": "'Ve 3 tane daha'"
   },
@@ -153,13 +163,17 @@
   "removeTracks": "{count, plural, =1{Parçayı kaldır} other{{count} adet parçayı kaldır}}",
   "@removeTracks": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "removeTracksConfirmation": "{count, plural, =1{Kaldırmak istediğine emin misin {title}?} other{Seçili parçaları kaldırmak istediğinizden emin misiniz?}}",
   "@removeTracksConfirmation": {
     "placeholders": {
-      "count": {},
+      "count": {
+        "type": "num"
+      },
       "title": {
         "type": "String?",
         "example": "Parça adı"
@@ -171,13 +185,17 @@
   "deleteTracks": "{count, plural, =1{Parçayı sil} other{{count} adet parçayı sil}}",
   "@deleteTracks": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "deleteTracksConfirmation": "{count, plural, =1{Silmek istediğine emin misin {title}?} other{Seçili parçaları silmek istediğinizden emin misiniz?}}",
   "@deleteTracksConfirmation": {
     "placeholders": {
-      "count": {},
+      "count": {
+        "type": "num"
+      },
       "title": {
         "type": "String?",
         "example": "Parça adı"
@@ -188,13 +206,17 @@
   "deletePlaylists": "{count, plural, =1{Oynatma listesini sil} other{{count} adet oynatma listesini silin}}",
   "@deletePlaylists": {
     "placeholders": {
-      "count": {}
+      "count": {
+        "type": "num"
+      }
     }
   },
   "deletePlaylistsConfirmation": "{count, plural, =1{Silmek istediğinize emin misiniz {title}?} other{Seçili oynatma listelerini silmek istediğinize emin misiniz?}}",
   "@deletePlaylistsConfirmation": {
     "placeholders": {
-      "count": {},
+      "count": {
+        "type": "num"
+      },
       "title": {
         "type": "String?",
         "example": "Oynatma listesi adı"
@@ -271,7 +293,9 @@
   "onThePathToDevModeClicksRemaining": "{remainingClicks, plural, =1{Neredeyse ulaştın, sadece 1 tıklama kaldı...} other{Neredeyse ulaştın, sadece {remainingClicks} tıklama kaldı...}}",
   "@onThePathToDevModeClicksRemaining": {
     "placeholders": {
-      "remainingClicks": {}
+      "remainingClicks": {
+        "type": "num"
+      }
     },
     "description": "Kullanıcı geliştirici olmak üzereyken gösterilir, 2. bölüm"
   },

--- a/lib/logic/player/music_player.dart
+++ b/lib/logic/player/music_player.dart
@@ -181,6 +181,11 @@ class _BrowserParentProvider {
 
 @visibleForTesting
 class AudioHandler extends BaseAudioHandler with SeekHandler, WidgetsBindingObserver {
+  @visibleForTesting
+  static const loopOn = 'loop_on';
+  @visibleForTesting
+  static const loopOff = 'loop_off';
+
   AudioHandler(MusicPlayer player) {
     _init(player);
   }
@@ -433,7 +438,7 @@ class AudioHandler extends BaseAudioHandler with SeekHandler, WidgetsBindingObse
   }
 
   @override
-  Future<void> setRating(Rating rating, Map? extras) {
+  Future<void> setRating(Rating rating, [Map<String, dynamic>? extras]) async {
     // TODO: implement setRating
     throw UnimplementedError();
   }
@@ -497,20 +502,11 @@ class AudioHandler extends BaseAudioHandler with SeekHandler, WidgetsBindingObse
   }
 
   @override
-  Future<void> onNotificationAction(String action) async {
-    switch (action) {
-      case 'loop_on':
-      case 'loop_off':
+  Future<dynamic> customAction(String name, [Map<String, dynamic>? extras]) {
+    switch (name) {
+      case loopOn:
+      case loopOff:
         return player.switchLooping();
-      case 'play_prev':
-        return player.playPrev();
-      case 'pause':
-      case 'play':
-        return player.playPause();
-      case 'play_next':
-        return player.playNext();
-      case 'stop':
-        return stop();
       default:
         throw UnimplementedError();
     }
@@ -531,45 +527,44 @@ class AudioHandler extends BaseAudioHandler with SeekHandler, WidgetsBindingObse
     final l10n = staticl10n;
     playbackState.add(playbackState.value!.copyWith(
       controls: [
-        // TODO: currently using custom API from my fork, see https://github.com/ryanheise/audio_service/issues/633
         if (player.looping)
-          MediaControl(
+          MediaControl.custom(
             androidIcon: 'drawable/round_loop_one',
             label: l10n.loopOn,
-            action: 'loop_on',
+            name: loopOn,
           )
         else
-          MediaControl(
+          MediaControl.custom(
             androidIcon: 'drawable/round_loop',
             label: l10n.loopOff,
-            action: 'loop_off',
+            name: loopOff,
           ),
         MediaControl(
           androidIcon: 'drawable/round_skip_previous',
           label: l10n.previous,
-          action: 'play_prev',
+          action: MediaAction.skipToPrevious,
         ),
         if (playing)
           MediaControl(
             androidIcon: 'drawable/round_pause',
             label: l10n.pause,
-            action: 'pause',
+            action: MediaAction.pause,
           )
         else
           MediaControl(
             androidIcon: 'drawable/round_play_arrow',
             label: l10n.play,
-            action: 'play',
+            action: MediaAction.play,
           ),
         MediaControl(
           androidIcon: 'drawable/round_skip_next',
           label: l10n.next,
-          action: 'play_next',
+          action: MediaAction.skipToNext,
         ),
         MediaControl(
           androidIcon: 'drawable/round_stop',
           label: l10n.stop,
-          action: 'stop',
+          action: MediaAction.stop,
         ),
       ],
       systemActions: const {
@@ -601,14 +596,14 @@ class AudioHandler extends BaseAudioHandler with SeekHandler, WidgetsBindingObse
       androidCompactActionIndices: const [1, 2, 3],
       repeatMode: player.looping ? AudioServiceRepeatMode.one : AudioServiceRepeatMode.all,
       shuffleMode: QueueControl.instance.state.shuffled ? AudioServiceShuffleMode.all : AudioServiceShuffleMode.none,
-      processingState: const {
-        ProcessingState.idle: AudioProcessingState.idle,
-        ProcessingState.loading: AudioProcessingState.loading,
-        ProcessingState.buffering: AudioProcessingState.buffering,
-        ProcessingState.ready: AudioProcessingState.ready,
-        ProcessingState.completed: AudioProcessingState.completed,
-        // Excluding idle state because it makes notification to reappear.
-      }[player.processingState == ProcessingState.idle ? ProcessingState.loading : player.processingState],
+      processingState: switch (
+          player.processingState == ProcessingState.idle ? ProcessingState.loading : player.processingState) {
+        ProcessingState.idle => AudioProcessingState.idle,
+        ProcessingState.loading => AudioProcessingState.loading,
+        ProcessingState.buffering => AudioProcessingState.buffering,
+        ProcessingState.ready => AudioProcessingState.ready,
+        ProcessingState.completed => AudioProcessingState.completed,
+      },
       playing: playing,
       updatePosition: player.position,
       bufferedPosition: player.bufferedPosition,
@@ -667,7 +662,6 @@ class MusicPlayer extends AudioPlayer {
         // artDownscaleHeight,
         fastForwardInterval: const Duration(seconds: 5),
         rewindInterval: const Duration(seconds: 5),
-        androidEnableQueue: true,
         preloadArtwork: false,
         // androidBrowsableRootExtras,
       ),

--- a/lib/logic/player/music_player.dart
+++ b/lib/logic/player/music_player.dart
@@ -347,7 +347,9 @@ class AudioHandler extends BaseAudioHandler with SeekHandler, WidgetsBindingObse
   @override
   Future<void> stop() async {
     running = false;
-    await player.stop();
+    if (!_disposed) {
+      await player.stop();
+    }
     await super.stop();
   }
 

--- a/lib/logic/player/music_player.dart
+++ b/lib/logic/player/music_player.dart
@@ -598,10 +598,9 @@ class AudioHandler extends BaseAudioHandler with SeekHandler, WidgetsBindingObse
       androidCompactActionIndices: const [1, 2, 3],
       repeatMode: player.looping ? AudioServiceRepeatMode.one : AudioServiceRepeatMode.all,
       shuffleMode: QueueControl.instance.state.shuffled ? AudioServiceShuffleMode.all : AudioServiceShuffleMode.none,
-      processingState: switch (
-          player.processingState == ProcessingState.idle ? ProcessingState.loading : player.processingState) {
-        ProcessingState.idle => AudioProcessingState.idle,
-        ProcessingState.loading => AudioProcessingState.loading,
+      processingState: switch (player.processingState) {
+        // Treat `idle` like `loading` state to avoid making the notification reappear.
+        ProcessingState.idle || ProcessingState.loading => AudioProcessingState.loading,
         ProcessingState.buffering => AudioProcessingState.buffering,
         ProcessingState.ready => AudioProcessingState.ready,
         ProcessingState.completed => AudioProcessingState.completed,

--- a/lib/routes/home_route/player_route.dart
+++ b/lib/routes/home_route/player_route.dart
@@ -878,7 +878,7 @@ class _InfoButton extends StatelessWidget {
             ),
           ),
           additionalActions: [
-            CopyButton(text: songInfo),
+            IntrinsicWidth(child: CopyButton(text: songInfo)),
           ],
         );
       },

--- a/lib/widgets/show_functions.dart
+++ b/lib/widgets/show_functions.dart
@@ -171,7 +171,7 @@ class ShowFunctions extends NFShowFunctions {
                   ),
                 ),
                 additionalActions: [
-                  CopyButton(text: errorDetails),
+                  IntrinsicWidth(child: CopyButton(text: errorDetails)),
                 ],
               );
             },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -772,11 +772,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "update/flutter"
-      resolved-ref: "694631de694fabe64d1795ae3b61bae4febcaea3"
-      url: "https://github.com/Abestanis/nt4f04unds_widgets"
+      ref: "5.0.0"
+      resolved-ref: c70e75a6ffbb69f8c2594ecd88b8f22c98906450
+      url: "https://github.com/nt4f04uNd/nt4f04unds_widgets"
     source: git
-    version: "4.0.1"
+    version: "5.0.0"
   octo_image:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
+      sha256: dc27559385e905ad30838356c5f5d574014ba39872d732111cd07ac0beff4c57
       url: "https://pub.dev"
     source: hosted
-    version: "67.0.0"
+    version: "80.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
+      sha256: "192d1c5b944e7e53b24b5586db760db934b177d4147c42fbca8c8c5f1eb8d11e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.1"
+    version: "7.3.0"
   android_content_provider:
     dependency: "direct main"
     description:
@@ -45,18 +45,18 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
+      sha256: "7dcbd0f87fe5f61cb28da39a1a8b70dbc106e2fe0516f7836eb7bb2948481a12"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.1"
+    version: "4.0.5"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.0"
   async:
     dependency: "direct main"
     description:
@@ -136,58 +136,50 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
+      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "79b2aef6ac2ed00046867ed354c88778c9c0f029df8a20fe10b5436826721ef9"
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.0.4"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
+      sha256: b9e4fda21d846e192628e7a4f6deda6888c36b5b69ba02ff291a01fd529140f0
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "644dc98a0f179b872f612d3eb627924b578897c629788e858157fa5e704ca0c7"
+      sha256: "058fe9dce1de7d69c4b84fada934df3e0153dd000758c4d65964d0166779aa99"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.11"
+    version: "2.4.15"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: e3c79f69a64bdfcd8a776a3c28db4eb6e3fb5356d013ae5eb2e52007706d5dbe
+      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.1"
-  build_test:
-    dependency: transitive
-    description:
-      name: build_test
-      sha256: "260dbba934f41b0a42935e9cae1f5731b94f0c3e489dc97bcf8e281265aaa5ae"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.2"
+    version: "8.0.0"
   built_collection:
     dependency: transitive
     description:
@@ -200,10 +192,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: c7913a9737ee4007efedaffc968c049fd0f3d0e49109e778edc10de9426005cb
+      sha256: ea90e81dc4a25a043d9bee692d20ed6d1c4a1662a28c03a96417446c093ed6b4
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.2"
+    version: "8.9.5"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -280,10 +272,10 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: f692079e25e7869c14132d39f223f8eec9830eb76131925143b2129c4bb01b37
+      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.0"
+    version: "4.10.1"
   collection:
     dependency: "direct main"
     description:
@@ -296,50 +288,34 @@ packages:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
-  coverage:
-    dependency: transitive
-    description:
-      name: coverage
-      sha256: c1fb2dce3c0085f39dc72668e85f8e0210ec7de05345821ff58530567df345a5
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.9.2"
+    version: "3.1.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      sha256: "706b5707578e0c1b4b7550f64078f0a0f19dec3f50a178ffae7006b0a9ca58fb"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
+    version: "3.0.6"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
+      sha256: "27eb0ae77836989a3bc541ce55595e8ceee0992807f14511552a898ddd0d88ac"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.6"
+    version: "3.0.1"
   device_info_plus:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: "72d146c6d7098689ff5c5f66bcf593ac11efc530095385356e131070333e64da"
+      sha256: "306b78788d1bb569edb7c55d622953c2414ca12445b41c9117963e03afc5c513"
       url: "https://pub.dev"
     source: hosted
-    version: "11.3.0"
+    version: "11.3.3"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -352,10 +328,10 @@ packages:
     dependency: transitive
     description:
       name: enum_to_string
-      sha256: bd9e83a33b754cb43a75b36a9af2a0b92a757bfd9847d2621ca0b1bed45f8e7a
+      sha256: "93b75963d3b0c9f6a90c095b3af153e1feccb79f6f08282d3274ff8d9eea52bc"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.2.1"
   equatable:
     dependency: "direct main"
     description:
@@ -384,18 +360,18 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   firebase_analytics:
     dependency: "direct main"
     description:
@@ -464,10 +440,10 @@ packages:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -540,10 +516,10 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: a434911f643466d78462625df76fd9eb13e57348ff43fe1f77bbe909522c67a1
+      sha256: "59a584c24b3acdc5250bb856d0d3e9c0b798ed14a4af1ddb7dc1c7b41df91c9c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.2"
+    version: "2.5.8"
   freezed_annotation:
     dependency: "direct main"
     description:
@@ -564,10 +540,10 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   golden_toolkit:
     dependency: "direct dev"
     description:
@@ -588,10 +564,10 @@ packages:
     dependency: "direct main"
     description:
       name: home_widget
-      sha256: b313e3304c0429669fddf1286e1fbf61a64b873f38ba30b3eb890ef0d7560b12
+      sha256: "7430f7549d42cef2e729bd3c779de748b93f1eb78b1abfe6bca8fffd1cfce3e9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.0+1"
   hooks_riverpod:
     dependency: "direct main"
     description:
@@ -600,38 +576,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      sha256: "3a7812d5bcd2894edf53dfaf8cd640876cf6cef50a8f238745c8b8120ea74d3a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.15.4"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
+      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.2"
   intl:
     dependency: transitive
     description:
@@ -644,18 +612,18 @@ packages:
     dependency: transitive
     description:
       name: io
-      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.7.2"
   json_annotation:
     dependency: "direct main"
     description:
@@ -668,10 +636,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: ea1432d167339ea9b5bb153f0571d0039607a873d6e04e0117af043f14a1fd4b
+      sha256: "81f04dee10969f89f604e1249382d46b97a1ccad53872875369622b5bfc9e58a"
       url: "https://pub.dev"
     source: hosted
-    version: "6.8.0"
+    version: "6.9.4"
   just_audio:
     dependency: "direct main"
     description:
@@ -732,26 +700,26 @@ packages:
     dependency: transitive
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   lottie:
     dependency: "direct main"
     description:
       name: lottie
-      sha256: "7afc60865a2429d994144f7d66ced2ae4305fe35d82890b8766e3359872d872c"
+      sha256: c5fa04a80a620066c15cf19cc44773e19e9b38e989ff23ea32e5903ef1015950
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.3.1"
   marquee:
     dependency: "direct main"
     description:
       name: marquee
-      sha256: "4b5243d2804373bdc25fc93d42c3b402d6ec1f4ee8d0bb72276edd04ae7addb8"
+      sha256: a87e7e80c5d21434f90ad92add9f820cf68be374b226404fe881d2bba7be0862
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.3.0"
   matcher:
     dependency: transitive
     description:
@@ -788,10 +756,10 @@ packages:
     dependency: transitive
     description:
       name: mime
-      sha256: "801fd0b26f14a4a58ccb09d5892c3fbdeff209594300a542492cf13fba9d247a"
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "2.0.0"
   multiple_localization:
     dependency: transitive
     description:
@@ -800,14 +768,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
-  node_preamble:
-    dependency: transitive
-    description:
-      name: node_preamble
-      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2"
   nt4f04unds_widgets:
     dependency: "direct main"
     description:
@@ -829,10 +789,10 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   package_info_plus:
     dependency: "direct main"
     description:
@@ -853,10 +813,10 @@ packages:
     dependency: "direct main"
     description:
       name: palette_generator
-      sha256: d50fbcd69abb80c5baec66d700033b1a320108b1aa17a5961866a12c0abb7c0c
+      sha256: "5a96b78983752faeb94866b30cb8f52e94ef176722bf51d1c5541d6a3044368f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+4"
+    version: "0.3.3+6"
   path:
     dependency: "direct main"
     description:
@@ -877,18 +837,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "6f01f8e37ec30b07bc424b4deabac37cacb1bc7e2e515ad74486039918a37eb7"
+      sha256: "0ca7359dad67fd7063cb2892ab0c0737b2daafd807cf1acecd62374c8fae6c12"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.10"
+    version: "2.2.16"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: f234384a3fdd67f989b4d54a5d73ca2a6c422fa55ae694381ae0f4375cd1ea16
+      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -925,42 +885,42 @@ packages:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: "18bf33f7fefbd812f37e72091a15575e72d5318854877e0e4035a24ac1113ecb"
+      sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
       url: "https://pub.dev"
     source: hosted
-    version: "11.3.1"
+    version: "11.4.0"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: "76e4ab092c1b240d31177bb64d2b0bea43f43d0e23541ec866151b9f7b2490fa"
+      sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.12"
+    version: "12.1.0"
   permission_handler_apple:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: e6f6d73b12438ef13e648c4ae56bd106ec60d17e90a59c4545db6781229082a0
+      sha256: f84a188e79a35c687c132a0a0556c254747a08561e99ab933f12f6ca71ef3c98
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.5"
+    version: "9.4.6"
   permission_handler_html:
     dependency: transitive
     description:
       name: permission_handler_html
-      sha256: af26edbbb1f2674af65a8f4b56e1a6f526156bc273d0e65dd8075fab51c78851
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3+2"
+    version: "0.1.3+5"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      sha256: fe0ffe274d665be8e34f9c59705441a7d248edebbe5d9e3ec2665f88b79358ea
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.2"
+    version: "4.3.0"
   permission_handler_windows:
     dependency: transitive
     description:
@@ -973,10 +933,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -993,22 +953,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: a0117dc2167805aa9125b82eee515cc891819bac2f538c83646d355b16f58b9a
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.1"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: c799b721d79eb6ee6fa56f00c04b472dcd44a30d258fac2174a6ec57302678f8
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.5.0"
   riverpod:
     dependency: "direct main"
     description:
@@ -1029,26 +997,26 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "95f9997ca1fb9799d494d0cb2a780fd7be075818d59f00c43832ed112b158a82"
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.5.3"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "480ba4345773f56acda9abf5f50bd966f581dac5d514e5fc4a18c62976bbba7e"
+      sha256: "3ec7210872c4ba945e3244982918e502fa2bfb5230dff6832459ca0e1879b7ad"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.4.8"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: c4b35f6cb8f63c147312c054ce7c2254c8066745125264f0c88739c417fc9d9f
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.2"
+    version: "2.5.4"
   shared_preferences_linux:
     dependency: transitive
     description:
@@ -1069,10 +1037,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -1085,34 +1053,18 @@ packages:
     dependency: transitive
     description:
       name: shelf
-      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
-  shelf_packages_handler:
-    dependency: transitive
-    description:
-      name: shelf_packages_handler
-      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.2"
-  shelf_static:
-    dependency: transitive
-    description:
-      name: shelf_static
-      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.2"
+    version: "1.4.2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -1130,42 +1082,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
+      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
-  source_gen_test:
-    dependency: transitive
-    description:
-      name: source_gen_test
-      sha256: ba9ec63c8f4f4d91021e5e09dd8259dc3bdfbd13cd027d91d761201542bc4a1f
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
+    version: "2.0.0"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "6adebc0006c37dd63fe05bca0a929b99f06402fc95aa35bf36d67f5c06de01fd"
+      sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.4"
-  source_map_stack_trace:
-    dependency: transitive
-    description:
-      name: source_map_stack_trace
-      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.2"
-  source_maps:
-    dependency: transitive
-    description:
-      name: source_maps
-      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.12"
+    version: "1.3.5"
   source_span:
     dependency: transitive
     description:
@@ -1186,34 +1114,58 @@ packages:
     dependency: "direct main"
     description:
       name: sqflite
-      sha256: a43e5a27235518c03ca238e7b4732cf35eabe863a369ceba6cbefa537a66f16d
+      sha256: e2297b1da52f127bc7a3da11439985d9b536f75070f3325e62ada69a5c585d03
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3+1"
+    version: "2.4.2"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: "2b3070c5fa881839f8b402ee4a39c1b4d561704d4ebbbcfb808a119bc2a1701b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "3da423ce7baf868be70e2c0976c28a1bb2f73644268b7ffa7d2e08eab71f16a4"
+      sha256: "84731e8bfd8303a3389903e01fb2141b6e59b5973cacbb0929021df08dddbe8b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "2.5.5"
   sqflite_common_ffi:
     dependency: "direct dev"
     description:
       name: sqflite_common_ffi
-      sha256: "4d6137c29e930d6e4a8ff373989dd9de7bac12e3bc87bce950f6e844e8ad3bb5"
+      sha256: "1f3ef3888d3bfbb47785cc1dda0dc7dd7ebd8c1955d32a9e8e9dae1e38d1c4c1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.3.5"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: bb174b3ec2527f9c5f680f73a89af8149dd99782fbb56ea88ad0807c5638f2ed
+      sha256: "310af39c40dd0bb2058538333c9d9840a2725ae0b9f77e4fd09ad6696aa8f66e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.7"
+    version: "2.7.5"
   stack_trace:
     dependency: transitive
     description:
@@ -1242,10 +1194,10 @@ packages:
     dependency: transitive
     description:
       name: stream_transform
-      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -1273,10 +1225,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "539ef412b170d65ecdafd780f924e5be3f60032a1128df156adad6c5b373d558"
+      sha256: "0669c70faae6270521ee4f05bffd2919892d42d1276e6c495be80174b6bc0ef6"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0+1"
+    version: "3.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -1285,14 +1237,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
-  test:
-    dependency: transitive
-    description:
-      name: test
-      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.25.15"
   test_api:
     dependency: transitive
     description:
@@ -1301,22 +1245,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
-  test_core:
-    dependency: transitive
-    description:
-      name: test_core
-      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.8"
   theme_tailor:
     dependency: "direct dev"
     description:
       name: theme_tailor
-      sha256: "176c88b37f56996c2dc7b9e426a2db6fd66f95e1454288f7205ea4faa9380a3a"
+      sha256: "8f2444f3833e6730ef308d5e3d97c258a780b897483e509d722a5a1a6c591932"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   theme_tailor_annotation:
     dependency: "direct main"
     description:
@@ -1329,18 +1265,18 @@ packages:
     dependency: transitive
     description:
       name: timing
-      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   url_launcher:
     dependency: "direct main"
     description:
@@ -1353,34 +1289,34 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: f0c73347dfcfa5b3db8bc06e1502668265d39c08f310c29bff4e28eea9699f79
+      sha256: "1d0eae19bd7606ef60fe69ef3b312a437a16549476c42321d5dc1506c9ca3bf4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.9"
+    version: "6.3.15"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: e43b677296fadce447e987a2f519dcf5f6d1e527dc35d01ffab4fff5b8a7063e
+      sha256: "16a513b6c12bb419304e72ea0ae2ab4fed569920d1c7cb850263fe3acc824626"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: e2b9622b4007f97f504cd64c0128309dfb978ae66adbe944125ed9e1750f06af
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "9a1a42d5d2d95400c795b2914c36fdcb525870c752569438e4ebb09a2b5d90de"
+      sha256: "17ba2000b847f334f16626a574c702b196723af2a289e7a93ffcb79acff855c2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.2"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1393,18 +1329,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e"
+      sha256: "3ba963161bd0fe395917ba881d320b9c4f6dd3c4a233da62ab18a5025c85f1e9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.0"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.4"
   uuid:
     dependency: "direct main"
     description:
@@ -1441,58 +1377,58 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
+      sha256: "69da27e49efa56a15f8afe8f4438c4ec02eff0a117df1b22ea4aad194fe1c104"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   web:
     dependency: transitive
     description:
       name: web
-      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: "0b8e2457400d8a859b7b2030786835a28a8e80836ef64402abef392ff4f1d0e5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
-  webkit_inspection_protocol:
-    dependency: transitive
-    description:
-      name: webkit_inspection_protocol
-      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.1"
+    version: "3.0.2"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: "68d1e89a91ed61ad9c370f9f8b6effed9ae5e0ede22a270bdfa6daf79fc2290a"
+      sha256: dc6ecaa00a7c708e5b4d10ee7bec8c270e9276dfcab1783f57e9962d7884305f
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.4"
+    version: "5.12.0"
   win32_registry:
     dependency: transitive
     description:
       name: win32_registry
-      sha256: "723b7f851e5724c55409bb3d5a32b203b3afe8587eaf5dafb93a5fed8ecda0d6"
+      sha256: "6f1b564492d0147b330dd794fee8f512cec4977957f310f9951b5f9d83618dae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.4"
+    version: "2.1.0"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.1.0"
   xmlstream:
     dependency: transitive
     description:
@@ -1505,10 +1441,10 @@ packages:
     dependency: transitive
     description:
       name: yaml
-      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.29.2"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -813,7 +813,7 @@ packages:
     description:
       path: "."
       ref: "update/flutter"
-      resolved-ref: d6d94415e31b5db1ade23f8f7ead2ef9c71f66e6
+      resolved-ref: "694631de694fabe64d1795ae3b61bae4febcaea3"
       url: "https://github.com/Abestanis/nt4f04unds_widgets"
     source: git
     version: "4.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -61,37 +61,37 @@ packages:
     dependency: "direct main"
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   audio_service:
     dependency: "direct main"
     description:
       path: audio_service
       ref: sweyer
-      resolved-ref: "1e92412fcd76c43fc88c9b1157b855d097b7c9b3"
+      resolved-ref: "469a0ba9bd7d1722af18f0e40cca74a728d6532d"
       url: "https://github.com/nt4f04uNd/audio_service"
     source: git
-    version: "0.16.2"
+    version: "0.18.18"
   audio_service_platform_interface:
     dependency: transitive
     description:
       path: audio_service_platform_interface
       ref: sweyer
-      resolved-ref: "1e92412fcd76c43fc88c9b1157b855d097b7c9b3"
+      resolved-ref: "469a0ba9bd7d1722af18f0e40cca74a728d6532d"
       url: "https://github.com/nt4f04und/audio_service.git"
     source: git
-    version: "1.0.0"
+    version: "0.1.3"
   audio_service_web:
     dependency: transitive
     description:
       path: audio_service_web
       ref: sweyer
-      resolved-ref: "1e92412fcd76c43fc88c9b1157b855d097b7c9b3"
+      resolved-ref: "469a0ba9bd7d1722af18f0e40cca74a728d6532d"
       url: "https://github.com/nt4f04und/audio_service.git"
     source: git
-    version: "0.16.2"
+    version: "0.1.4"
   audio_session:
     dependency: transitive
     description:
@@ -120,10 +120,10 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   boxy:
     dependency: "direct main"
     description:
@@ -232,10 +232,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -248,10 +248,10 @@ packages:
     dependency: "direct main"
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   cloud_functions:
     dependency: "direct main"
     description:
@@ -288,10 +288,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
@@ -376,10 +376,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -700,18 +700,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -756,18 +756,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   memoize:
     dependency: "direct main"
     description:
@@ -780,10 +780,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -812,11 +812,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "4.0.0"
-      resolved-ref: f6cc09477e7c7ba40054b0b2bf18523063ea5619
-      url: "https://github.com/nt4f04uNd/nt4f04unds_widgets"
+      ref: "update/flutter"
+      resolved-ref: d6d94415e31b5db1ade23f8f7ead2ef9c71f66e6
+      url: "https://github.com/Abestanis/nt4f04unds_widgets"
     source: git
-    version: "4.0.0"
+    version: "4.0.1"
   octo_image:
     dependency: transitive
     description:
@@ -861,10 +861,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_provider:
     dependency: "direct main"
     description:
@@ -1117,7 +1117,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   sliver_tools:
     dependency: "direct main"
     description:
@@ -1170,10 +1170,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   sprintf:
     dependency: transitive
     description:
@@ -1218,10 +1218,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   state_notifier:
     dependency: transitive
     description:
@@ -1234,10 +1234,10 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
@@ -1250,10 +1250,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.4.1"
   styled_text:
     dependency: "direct main"
     description:
@@ -1281,34 +1281,34 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test:
     dependency: transitive
     description:
       name: test
-      sha256: "7ee446762c2c50b3bd4ea96fe13ffac69919352bd3b4b17bac3f3465edc58073"
+      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.2"
+    version: "1.25.15"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.4"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "2bc4b4ecddd75309300d8096f781c0e3280ca1ef85beda558d33fcbedc2eead4"
+      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.8"
   theme_tailor:
     dependency: "direct dev"
     description:
@@ -1433,10 +1433,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.3.1"
   watcher:
     dependency: transitive
     description:
@@ -1510,5 +1510,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.1 <4.0.0"
-  flutter: ">=3.22.2"
+  dart: ">=3.7.0-0 <4.0.0"
+  flutter: ">=3.29.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ version: 1.0.13+16
 
 environment:
   sdk: '>=3.4.1 <4.0.0'
-  flutter: 3.22.2
+  flutter: 3.29.2
 
 dependencies:
   flutter:
@@ -77,8 +77,8 @@ dependencies:
     # path: /Users/nt4f04und/dev/prj/nt4f04unds_widgets
 
     git:
-      url: https://github.com/nt4f04uNd/nt4f04unds_widgets
-      ref: 4.0.0
+      url: https://github.com/Abestanis/nt4f04unds_widgets
+      ref: update/flutter
 
   sweyer_plugin:
     path: sweyer_plugin

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -77,8 +77,8 @@ dependencies:
     # path: /Users/nt4f04und/dev/prj/nt4f04unds_widgets
 
     git:
-      url: https://github.com/Abestanis/nt4f04unds_widgets
-      ref: update/flutter
+      url: https://github.com/nt4f04uNd/nt4f04unds_widgets
+      ref: 5.0.0
 
   sweyer_plugin:
     path: sweyer_plugin

--- a/sweyer_plugin/android/build.gradle
+++ b/sweyer_plugin/android/build.gradle
@@ -2,14 +2,14 @@ group = "com.nt4f04und.sweyer.sweyer_plugin"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "1.7.10"
+    ext.kotlin_version = "2.0.20"
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:7.3.0")
+        classpath("com.android.tools.build:gradle:8.3.2")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
@@ -32,12 +32,12 @@ android {
     compileSdk = 34
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     sourceSets {

--- a/test/fakes/fake_just_audio.dart
+++ b/test/fakes/fake_just_audio.dart
@@ -96,7 +96,6 @@ class MockAudioPlayer extends AudioPlayerPlatform {
   ProcessingStateMessage _processingState = ProcessingStateMessage.idle;
   Duration _updatePosition = Duration.zero;
   DateTime _updateTime = DateTime.now();
-  // ignore: prefer_final_fields
   Duration? _duration;
   int? _index;
   var _playing = false;

--- a/test/logic/player/music_player_test.dart
+++ b/test/logic/player/music_player_test.dart
@@ -1,6 +1,7 @@
 import 'package:audio_service/audio_service.dart';
 import 'package:rxdart/rxdart.dart';
 
+import 'package:sweyer/logic/player/music_player.dart' as sweyer_music_player;
 import '../../test.dart';
 
 void main() {
@@ -36,11 +37,15 @@ void main() {
         expect(
           playbackState.controls.map((control) => control.toString()),
           [
-            MediaControl(androidIcon: 'drawable/round_loop', label: l10n.loopOff, action: 'loop_off'),
-            MediaControl(androidIcon: 'drawable/round_skip_previous', label: l10n.previous, action: 'play_prev'),
-            MediaControl(androidIcon: 'drawable/round_pause', label: l10n.pause, action: 'pause'),
-            MediaControl(androidIcon: 'drawable/round_skip_next', label: l10n.next, action: 'play_next'),
-            MediaControl(androidIcon: 'drawable/round_stop', label: l10n.stop, action: 'stop'),
+            MediaControl.custom(
+                androidIcon: 'drawable/round_loop',
+                label: l10n.loopOff,
+                name: sweyer_music_player.AudioHandler.loopOff),
+            MediaControl(
+                androidIcon: 'drawable/round_skip_previous', label: l10n.previous, action: MediaAction.skipToPrevious),
+            MediaControl(androidIcon: 'drawable/round_pause', label: l10n.pause, action: MediaAction.pause),
+            MediaControl(androidIcon: 'drawable/round_skip_next', label: l10n.next, action: MediaAction.skipToNext),
+            MediaControl(androidIcon: 'drawable/round_stop', label: l10n.stop, action: MediaAction.stop),
           ].map((control) => control.toString()),
         );
       });
@@ -60,11 +65,15 @@ void main() {
         expect(
           playbackState.controls.map((control) => control.toString()),
           [
-            MediaControl(androidIcon: 'drawable/round_loop', label: l10n.loopOff, action: 'loop_off'),
-            MediaControl(androidIcon: 'drawable/round_skip_previous', label: l10n.previous, action: 'play_prev'),
-            MediaControl(androidIcon: 'drawable/round_play_arrow', label: l10n.play, action: 'play'),
-            MediaControl(androidIcon: 'drawable/round_skip_next', label: l10n.next, action: 'play_next'),
-            MediaControl(androidIcon: 'drawable/round_stop', label: l10n.stop, action: 'stop'),
+            MediaControl.custom(
+                androidIcon: 'drawable/round_loop',
+                label: l10n.loopOff,
+                name: sweyer_music_player.AudioHandler.loopOff),
+            MediaControl(
+                androidIcon: 'drawable/round_skip_previous', label: l10n.previous, action: MediaAction.skipToPrevious),
+            MediaControl(androidIcon: 'drawable/round_play_arrow', label: l10n.play, action: MediaAction.play),
+            MediaControl(androidIcon: 'drawable/round_skip_next', label: l10n.next, action: MediaAction.skipToNext),
+            MediaControl(androidIcon: 'drawable/round_stop', label: l10n.stop, action: MediaAction.stop),
           ].map((control) => control.toString()),
         );
       });
@@ -75,19 +84,23 @@ void main() {
       await binding.runAppTestWithoutUi(() async {
         MusicPlayer.instance.play();
         await binding.pump();
-        await MusicPlayer.handler!.onNotificationAction('stop');
+        await MusicPlayer.handler!.stop();
         await binding.pump();
         final playbackState = MusicPlayer.handler!.playbackState.value!;
         expect(playbackState.playing, false);
-        expect(playbackState.processingState, AudioProcessingState.ready);
+        expect(playbackState.processingState, AudioProcessingState.idle);
         expect(
           playbackState.controls.map((control) => control.toString()),
           [
-            MediaControl(androidIcon: 'drawable/round_loop', label: l10n.loopOff, action: 'loop_off'),
-            MediaControl(androidIcon: 'drawable/round_skip_previous', label: l10n.previous, action: 'play_prev'),
-            MediaControl(androidIcon: 'drawable/round_play_arrow', label: l10n.play, action: 'play'),
-            MediaControl(androidIcon: 'drawable/round_skip_next', label: l10n.next, action: 'play_next'),
-            MediaControl(androidIcon: 'drawable/round_stop', label: l10n.stop, action: 'stop'),
+            MediaControl.custom(
+                androidIcon: 'drawable/round_loop',
+                label: l10n.loopOff,
+                name: sweyer_music_player.AudioHandler.loopOff),
+            MediaControl(
+                androidIcon: 'drawable/round_skip_previous', label: l10n.previous, action: MediaAction.skipToPrevious),
+            MediaControl(androidIcon: 'drawable/round_play_arrow', label: l10n.play, action: MediaAction.play),
+            MediaControl(androidIcon: 'drawable/round_skip_next', label: l10n.next, action: MediaAction.skipToNext),
+            MediaControl(androidIcon: 'drawable/round_stop', label: l10n.stop, action: MediaAction.stop),
           ].map((control) => control.toString()),
         );
       });


### PR DESCRIPTION
Update to the newest Flutter version. This also updates all dependencies, but does not update any major versions, to keep this MR short (except `audio_service`). This also does not fix the new warnings. During build, there is a new warning:
```
Synthetic package output (package:flutter_gen) is deprecated: https://flutter.dev/to/flutter-gen-deprecation. In a future release, synthetic-package will default to `false`
and will later be removed entirely.
```
I'll address this in a future PR.

This PR depends on https://github.com/nt4f04uNd/nt4f04unds_widgets/pull/14, but is already ready for review.