### PR TITLE
Don't use a synthetic generated package for localizations

### DIFF
--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -31,6 +31,10 @@ runs:
         flutter pub get
         flutter pub get -C sweyer_plugin
 
+    - name: 🌐 Generate localizations
+      shell: bash
+      run: flutter gen-l10n
+
     - name: 📄 Check Dart formatting
       shell: bash
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ app.*.map.json
 
 # gen_l10n untranslated messages output, see l10n.yaml
 untranslated-messages.txt
+lib/localization/generated
 
 # Ignore golden failure outputs
 **/failures/*.png

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,4 +1,6 @@
+synthetic-package: false
 arb-dir: lib/localization/arb
+output-dir: lib/localization/generated
 #  Do not supply country code, gen_l10n currently doesn't handle it well
 #  https://github.com/flutter/flutter/issues/92731
 template-arb-file: intl_en.arb

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -6,3 +6,4 @@ output-dir: lib/localization/generated
 template-arb-file: intl_en.arb
 output-localization-file: app_localizations.dart
 untranslated-messages-file: untranslated-messages.txt
+format: true

--- a/lib/localization/localization.dart
+++ b/lib/localization/localization.dart
@@ -1,4 +1,4 @@
-export 'package:flutter_gen/gen_l10n/app_localizations.dart';
+export 'package:sweyer/localization/generated/app_localizations.dart';
 
 import 'package:flutter/material.dart';
 import 'package:sweyer/sweyer.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -96,7 +96,6 @@ dev_dependencies:
   sqflite_common_ffi: ^2.3.3
 
 flutter:
-  generate: true
   uses-material-design: true
 
   assets:

--- a/test/test.dart
+++ b/test/test.dart
@@ -14,11 +14,11 @@ import 'package:golden_toolkit/golden_toolkit.dart';
 import 'package:package_info_plus_platform_interface/package_info_platform_interface.dart';
 import 'package:package_info_plus_platform_interface/method_channel_package_info.dart';
 import 'package:just_audio_platform_interface/just_audio_platform_interface.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations_en.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:meta/meta.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:sweyer/constants.dart' as constants;
+import 'package:sweyer/localization/generated/app_localizations_en.dart';
 import 'package:sweyer_plugin/sweyer_plugin_platform_interface.dart';
 
 export 'fakes/fakes.dart';


### PR DESCRIPTION
This fixes the following warning on every build:
```
Synthetic package output (package:flutter_gen) is deprecated: https://flutter.dev/to/flutter-gen-deprecation. In a future release, synthetic-package will default to `false` and will later be removed entirely.
```

I've followed the [migration guide](https://docs.flutter.dev/release/breaking-changes/flutter-generate-i10n-source#migration-guide), now the sources are generated into `lib/localization/generated` instead of a synthetic package.