### PR TITLE
Let flutter automatically generate localization files on `pub get`

### DIFF
--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -31,6 +31,10 @@ runs:
         flutter pub get
         flutter pub get -C sweyer_plugin
 
+    - name: 🌐 Format generated localizations
+      shell: bash
+      run: dart format lib/localization/generated # TODO: Check if this is still necessary on the next Flutter update, maybe https://github.com/flutter/flutter/pull/167029 removes the need for this.
+
     - name: 📄 Check Dart formatting
       shell: bash
       run: |

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -31,10 +31,6 @@ runs:
         flutter pub get
         flutter pub get -C sweyer_plugin
 
-    - name: 🌐 Generate localizations
-      shell: bash
-      run: flutter gen-l10n
-
     - name: 📄 Check Dart formatting
       shell: bash
       run: |

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -97,6 +97,7 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  generate: true
 
   assets:
    - assets/


### PR DESCRIPTION
See https://github.com/nt4f04uNd/sweyer/pull/316#issuecomment-2799912277. Without the `generate: true`, flutter only generates them on `flutter build`. I thought in #316 that we need to get rid of this  setting to fix the warning, but it looks like we want it and it's ok to have it as long as we are not using the synthetic package.