### PR TITLE
Fix Android release signing after Gradle Kotlin DSL migration

### DIFF
--- a/.github/workflows/deploy_google_play/action.yml
+++ b/.github/workflows/deploy_google_play/action.yml
@@ -58,13 +58,18 @@ runs:
     - name: ⚙️ Generate key.properties
       shell: bash
       run: |
-        cat <<EOF > key.properties
+        cat <<EOF > "${{ github.workspace }}/android/key.properties"
         storePassword=${{ inputs.secrets_ANDROID_KEYSTORE_PASSWORD }}
         keyPassword=${{ inputs.secrets_ANDROID_KEY_PASSWORD }}
         keyAlias=${{ inputs.secrets_ANDROID_KEY_ALIAS }}
         storeFile=${{ steps.android_keystore.outputs.filePath }}
         EOF
-        mv key.properties ${{ github.workspace }}/android/key.properties
+
+    - name: ⚙️ Verify signing files exist
+      shell: bash
+      run: |
+        test -f "${{ github.workspace }}/android/key.properties"
+        test -f "${{ steps.android_keystore.outputs.filePath }}"
 
     - name: 📖 Read app version
       uses: NiklasLehnfeld/flutter-version-number-action@v1

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -44,7 +44,7 @@ android {
         create("release") {
             keyAlias = keystoreProperties["keyAlias"] as String?
             keyPassword = keystoreProperties["keyPassword"] as String?
-            storeFile = if ("storeFile" in keystoreProperties) file(keystoreProperties["storeFile"] as String) else null
+            storeFile = (keystoreProperties["storeFile"] as String?)?.let { rootProject.file(it) }
             storePassword = keystoreProperties["storePassword"] as String?
         }
     }


### PR DESCRIPTION
## Summary
- Resolve release keystore paths relative to the Android Gradle root project.
- Generate android/key.properties directly in the Google Play deploy workflow.
- Add CI file-existence checks for the generated signing properties and decoded keystore.

## Root Cause
PR #318 migrated the Android Gradle config to Kotlin DSL. The release signing config kept using file(...) for storeFile, which resolves relative paths from the android/app project directory. The local signing files follow the usual Flutter layout under android/, so storeFile=keystore_nt4f04und.jks was resolved from the wrong directory and release packaging failed with SigningConfig release is missing required property storeFile.

## Validation
- Parsed the release workflow YAML.
- Ran ./gradlew :app:packageRelease successfully locally.