### PR TITLE
Improve some CI workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,9 @@ updates:
       interval: "daily"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directory:
+      - "/"
+      - "/.github/workflows/*"
     schedule:
       interval: "daily"
 

--- a/.github/workflows/build_executables.yml
+++ b/.github/workflows/build_executables.yml
@@ -36,15 +36,6 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-
 
-      - name: 💾 Cache Android SDK components
-        uses: actions/cache@v5
-        with:
-          path: |
-            /usr/local/lib/android/sdk/ndk
-            /usr/local/lib/android/sdk/cmake
-            /usr/local/lib/android/sdk/platforms
-          key: android-sdk-${{ runner.os }}
-
       - name: 🔨 Build Apk
         shell: bash
         run: |

--- a/.github/workflows/build_executables.yml
+++ b/.github/workflows/build_executables.yml
@@ -21,7 +21,7 @@ jobs:
           channel: stable
           cache: true
 
-      - name: 💾 Cache Cache Pub
+      - name: 💾 Cache Pub
         uses: actions/cache@v5
         with:
           path: ~/.pub-cache

--- a/.github/workflows/build_executables.yml
+++ b/.github/workflows/build_executables.yml
@@ -2,7 +2,7 @@ name: Build Sweyer executables
 on:
   pull_request:
   push:
-    branches:    
+    branches:
       - main
       - master
       - 'releases/**'
@@ -28,8 +28,22 @@ jobs:
       - name: 💾 Cache Gradle
         uses: actions/cache@v5
         with:
-          key: gradle
-          path: /home/runner/.gradle
+          path: |
+            ~/.gradle/caches/modules-2
+            ~/.gradle/caches/transforms-3
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: 💾 Cache Android SDK components
+        uses: actions/cache@v5
+        with:
+          path: |
+            /usr/local/lib/android/sdk/ndk
+            /usr/local/lib/android/sdk/cmake
+            /usr/local/lib/android/sdk/platforms
+          key: android-sdk-${{ runner.os }}
 
       - name: 🔨 Build Apk
         shell: bash
@@ -42,3 +56,4 @@ jobs:
         with:
           name: Android Apk
           path: build/app/outputs/flutter-apk/app-profile.apk
+          compression-level: 0  # Executables are already compressed

--- a/.github/workflows/build_executables.yml
+++ b/.github/workflows/build_executables.yml
@@ -26,8 +26,7 @@ jobs:
         with:
           path: ~/.pub-cache
           key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
-          restore-keys: |
-            pub-${{ runner.os }}-
+          restore-keys: pub-${{ runner.os }}-
 
       - name: 💾 Cache Gradle
         uses: actions/cache@v5
@@ -36,8 +35,7 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
+          restore-keys: gradle-${{ runner.os }}-
 
       - name: 📦 Install Dependencies
         shell: bash

--- a/.github/workflows/build_executables.yml
+++ b/.github/workflows/build_executables.yml
@@ -21,9 +21,15 @@ jobs:
           channel: stable
           cache: true
 
-      - name: 📦 Install Dependencies
-        shell: bash
-        run: flutter pub get
+      - name: 💾 Cache Flutter build
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.pub-cache
+            build/
+          key: flutter-build-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+          restore-keys: |
+            flutter-build-${{ runner.os }}-
 
       - name: 💾 Cache Gradle
         uses: actions/cache@v5
@@ -35,6 +41,10 @@ jobs:
           key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-${{ runner.os }}-
+
+      - name: 📦 Install Dependencies
+        shell: bash
+        run: flutter pub get
 
       - name: 🔨 Build Apk
         shell: bash

--- a/.github/workflows/build_executables.yml
+++ b/.github/workflows/build_executables.yml
@@ -21,15 +21,13 @@ jobs:
           channel: stable
           cache: true
 
-      - name: 💾 Cache Flutter build
+      - name: 💾 Cache Cache Pub
         uses: actions/cache@v5
         with:
-          path: |
-            ~/.pub-cache
-            build/
-          key: flutter-build-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
           restore-keys: |
-            flutter-build-${{ runner.os }}-
+            pub-${{ runner.os }}-
 
       - name: 💾 Cache Gradle
         uses: actions/cache@v5

--- a/.github/workflows/build_executables.yml
+++ b/.github/workflows/build_executables.yml
@@ -33,8 +33,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            ~/.gradle/caches/modules-2
-            ~/.gradle/caches/transforms-3
+            ~/.gradle/caches
             ~/.gradle/wrapper
           key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |

--- a/.github/workflows/build_executables.yml
+++ b/.github/workflows/build_executables.yml
@@ -17,7 +17,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.29.2
+          flutter-version-file: pubspec.yaml
           channel: stable
           cache: true
 

--- a/.github/workflows/deploy_google_play/action.yml
+++ b/.github/workflows/deploy_google_play/action.yml
@@ -6,10 +6,6 @@ inputs:
     required: false
     default: "stable"
     description: The channel of the Flutter used to build Sweyer with. 
-  flutter_version:
-    required: false
-    default: "3.29.2"
-    description: The version of Flutter used to build Sweyer with.
   ruby_version:
     required: false
     default: 3.3.0
@@ -38,7 +34,7 @@ runs:
     - name: 🐦 Setup Flutter
       uses: subosito/flutter-action@v2
       with:
-        flutter-version: ${{inputs.flutter_version}}
+        flutter-version-file: pubspec.yaml
         channel: ${{inputs.flutter_channel}}
         cache: true
 

--- a/.github/workflows/deploy_google_play/action.yml
+++ b/.github/workflows/deploy_google_play/action.yml
@@ -120,22 +120,22 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: symbols
-        path: |
-          ${{ github.workspace }}/symbols.zip
+        path: ${{ github.workspace }}/symbols.zip
+        compression-level: 0  # Zip is already compressed
 
     - name: 📁 Upload build artifacts (aab)
       uses: actions/upload-artifact@v4
       with:
         name: sweyer@${{ steps.read-version.outputs.version-number }}.aab
-        path: |
-          ${{ github.workspace }}/build/app/outputs/bundle/release/sweyer@${{ steps.read-version.outputs.version-number }}.aab
+        path: ${{ github.workspace }}/build/app/outputs/bundle/release/sweyer@${{ steps.read-version.outputs.version-number }}.aab
+        compression-level: 0  # Aab is already compressed
 
     - name: 📁 Upload build artifacts (apk)
       uses: actions/upload-artifact@v4
       with:
         name: sweyer@${{ steps.read-version.outputs.version-number }}.apk
-        path: |
-          ${{ github.workspace }}/build/app/outputs/flutter-apk/sweyer@${{ steps.read-version.outputs.version-number }}.apk
+        path: ${{ github.workspace }}/build/app/outputs/flutter-apk/sweyer@${{ steps.read-version.outputs.version-number }}.apk
+        compression-level: 0  # Apk are already compressed
 
     - name: ⚙️ Decode Service Account Key JSON File
       uses: timheuer/base64-to-file@v1

--- a/.github/workflows/deploy_google_play/action.yml
+++ b/.github/workflows/deploy_google_play/action.yml
@@ -44,7 +44,7 @@ runs:
         ruby-version: ${{inputs.ruby_version}}
         bundler-cache: true
 
-    - name: 💾 Cache Cache Pub
+    - name: 💾 Cache Pub
       uses: actions/cache@v5
       with:
         path: ~/.pub-cache

--- a/.github/workflows/deploy_google_play/action.yml
+++ b/.github/workflows/deploy_google_play/action.yml
@@ -53,7 +53,7 @@ runs:
           pub-${{ runner.os }}-
 
     - name: ⚙️ Decode Keystore File
-      uses: timheuer/base64-to-file@v1
+      uses: timheuer/base64-to-file@v2
       id: android_keystore
       with:
         fileName: "keystore.jks"
@@ -76,7 +76,7 @@ runs:
         test -f "${{ steps.android_keystore.outputs.filePath }}"
 
     - name: 📖 Read app version
-      uses: NiklasLehnfeld/flutter-version-number-action@v1
+      uses: NiklasLehnfeld/flutter-version-number-action@v2
       id: read-version
       with:
         file-path: pubspec.yaml
@@ -117,21 +117,21 @@ runs:
         zip -r ${{ github.workspace }}/symbols.zip ${{ github.workspace }}/build/app/outputs/symbols/
 
     - name: 📁 Upload build artifacts (symbols)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: symbols
         path: ${{ github.workspace }}/symbols.zip
         compression-level: 0  # Zip is already compressed
 
     - name: 📁 Upload build artifacts (aab)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: sweyer@${{ steps.read-version.outputs.version-number }}.aab
         path: ${{ github.workspace }}/build/app/outputs/bundle/release/sweyer@${{ steps.read-version.outputs.version-number }}.aab
         compression-level: 0  # Aab is already compressed
 
     - name: 📁 Upload build artifacts (apk)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: sweyer@${{ steps.read-version.outputs.version-number }}.apk
         path: ${{ github.workspace }}/build/app/outputs/flutter-apk/sweyer@${{ steps.read-version.outputs.version-number }}.apk
@@ -175,7 +175,7 @@ runs:
         FASTLANE_ANDROID_JSON_KEY_FILE: ${{ steps.android_service_account_json_file.outputs.filePath }}
 
     - name: 📝 Draft a GitHub release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         name: ${{ steps.splitted-version.outputs._0 }}
         tag_name: ${{ steps.splitted-version.outputs._0 }}

--- a/.github/workflows/deploy_google_play/action.yml
+++ b/.github/workflows/deploy_google_play/action.yml
@@ -9,10 +9,6 @@ inputs:
   ruby_version:
     required: false
     default: 3.3.0
-  testing_arguments:
-    required: false
-    default: ""
-    description: Optional additional arguments to the flutter test command.
   secrets_ANDROID_KEYSTORE_FILE:
     required: true
   secrets_ANDROID_KEYSTORE_PASSWORD:

--- a/.github/workflows/deploy_google_play/action.yml
+++ b/.github/workflows/deploy_google_play/action.yml
@@ -44,6 +44,14 @@ runs:
         ruby-version: ${{inputs.ruby_version}}
         bundler-cache: true
 
+    - name: 💾 Cache Cache Pub
+      uses: actions/cache@v5
+      with:
+        path: ~/.pub-cache
+        key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+        restore-keys: |
+          pub-${{ runner.os }}-
+
     - name: ⚙️ Decode Keystore File
       uses: timheuer/base64-to-file@v1
       id: android_keystore

--- a/.github/workflows/deploy_google_play/action.yml
+++ b/.github/workflows/deploy_google_play/action.yml
@@ -135,7 +135,7 @@ runs:
       with:
         name: sweyer@${{ steps.read-version.outputs.version-number }}.apk
         path: ${{ github.workspace }}/build/app/outputs/flutter-apk/sweyer@${{ steps.read-version.outputs.version-number }}.apk
-        compression-level: 0  # Apk are already compressed
+        compression-level: 0  # Apk is already compressed
 
     - name: ⚙️ Decode Service Account Key JSON File
       uses: timheuer/base64-to-file@v1

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -26,8 +26,7 @@ runs:
       with:
         path: ~/.pub-cache
         key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
-        restore-keys: |
-          pub-${{ runner.os }}-
+        restore-keys: pub-${{ runner.os }}-
 
     - name: 📦 Install Dependencies
       shell: bash

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -6,10 +6,6 @@ inputs:
     required: false
     default: "stable"
     description: The channel of the Flutter used to build Sweyer with. 
-  flutter_version:
-    required: false
-    default: "3.29.2"
-    description: The version of Flutter used to build Sweyer with.
   testing_arguments:
     required: false
     default: ""
@@ -21,7 +17,7 @@ runs:
     - name: 🐦 Setup Flutter
       uses: subosito/flutter-action@v2
       with:
-        flutter-version: ${{inputs.flutter_version}}
+        flutter-version-file: pubspec.yaml
         channel: ${{inputs.flutter_channel}}
         cache: true
 

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -21,6 +21,14 @@ runs:
         channel: ${{inputs.flutter_channel}}
         cache: true
 
+    - name: 💾 Cache Cache Pub
+      uses: actions/cache@v5
+      with:
+        path: ~/.pub-cache
+        key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+        restore-keys: |
+          pub-${{ runner.os }}-
+
     - name: 📦 Install Dependencies
       shell: bash
       run: |

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -21,7 +21,7 @@ runs:
         channel: ${{inputs.flutter_channel}}
         cache: true
 
-    - name: 💾 Cache Cache Pub
+    - name: 💾 Cache Pub
       uses: actions/cache@v5
       with:
         path: ~/.pub-cache

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -59,7 +59,7 @@ runs:
 
     - name: 📁 Save golden test failures artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: golden-test-failures
         path: test/golden/failures


### PR DESCRIPTION
Reduces the execution time of the `build_executables` job by 50 to 60 seconds by improving the caching strategy. (See [main branch (`4m 29s`)](https://github.com/nt4f04uNd/sweyer/actions/runs/26190710556/job/77511673227) vs [this branch (`3m 39s`)](https://github.com/nt4f04uNd/sweyer/actions/runs/26190710556/job/77511673227)).

We also now read the flutter version from the pubspec file, it should never really differ.

Lastly, this updates some action versions and (hopefully) makes it so dependabot starts updating the local actions as well.